### PR TITLE
Feature/v0.3 arxiv import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PaperGraph MCP
 
-PaperGraph turns theorem-like environments in local LaTeX papers into a
-dependency graph exposed through MCP.
+PaperGraph turns theorem-like environments in local or arXiv LaTeX papers
+into a dependency graph exposed through MCP.
 
 ## Development
 
@@ -10,7 +10,7 @@ uv sync
 uv run pytest -q -p no:cacheprovider
 ```
 
-## Load a paper
+## Load a local paper
 
 Call the MCP `load_paper` tool with the root `.tex` file. PaperGraph v0.2
 recursively follows standard `\input{...}` and `\include{...}` commands.
@@ -19,3 +19,38 @@ and `.tex` is optional in those commands.
 
 The `list_theorems`, `get_theorem`, `get_dependencies`, and `where_used`
 tools operate on the resulting combined graph.
+
+## Load an arXiv paper
+
+PaperGraph v0.3 adds a dedicated `load_arxiv_paper` MCP tool:
+
+```text
+load_arxiv_paper(
+    arxiv_id="2401.12345",
+    main_file=None,
+    refresh=False,
+)
+```
+
+It accepts modern identifiers (`2401.12345`, `2401.12345v2`), legacy
+identifiers (`math/0307200`, `hep-th/9901001v3`), and an optional `arXiv:`
+prefix. URLs are not accepted. The tool downloads only from arXiv's fixed
+`https://export.arxiv.org/e-print/{id}` source endpoint, so network access is
+required for a paper that is not already cached.
+
+Downloaded sources are stored in the user's platform cache. A later call for
+the same identifier reuses the validated cache without another request. Pass
+`refresh=True` to fetch a replacement; a failed refresh leaves the existing
+valid cache intact.
+
+PaperGraph normally finds the root file by looking for uncommented
+`\documentclass` and `\begin{document}` commands, preferring `main.tex`,
+`paper.tex`, and `manuscript.tex` when needed. If multiple candidates remain,
+the error lists them. Retry with a project-relative path such as
+`main_file="src/article.tex"` to choose one explicitly.
+
+For safety, PaperGraph streams downloads and extraction, limits a compressed
+response to 100 MiB, limits extracted content to 500 MiB and 10,000 members,
+and rejects path traversal, links, devices, FIFOs, and other special archive
+members. Tar archives, compressed tar archives, gzip-compressed single TeX
+files, and plain single-file TeX responses are supported.

--- a/docs/superpowers/plans/2026-09-02-arxiv-import.md
+++ b/docs/superpowers/plans/2026-09-02-arxiv-import.md
@@ -1,0 +1,327 @@
+# arXiv Source Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a secure, cached `load_arxiv_paper` MCP tool that downloads an arXiv source package, selects its root LaTeX file, and activates the existing PaperGraph theorem graph.
+
+**Architecture:** Keep the server thin. `papergraph.archive` owns bounded source-package extraction, while `papergraph.arxiv` owns identifier normalization, fixed-endpoint HTTP streaming, main-file selection, transactional caching, and import orchestration. The server passes the selected root file through the existing loader/parser/graph pipeline and swaps global state only after the whole operation succeeds.
+
+**Tech Stack:** Python 3.10+, `httpx`, standard-library `tarfile`/`gzip`/`pathlib`/`json`/`tempfile`, MCP Python SDK v2, pytest, uv.
+
+## Global Constraints
+
+- Preserve `load_paper` and every v0.2 local-loading behavior.
+- Accept only modern and legacy arXiv identifiers, optionally prefixed by `arXiv:`; never accept a caller-controlled URL.
+- Limit downloads to 100 MiB, extracted data to 500 MiB, and archive members to 10,000.
+- Never extract absolute, drive-qualified, parent-traversing, linked, device, FIFO, or other special archive members.
+- Build replacements in a temporary sibling and publish only a completely validated cache entry.
+- Keep an existing valid cache entry intact when refresh fails.
+- Automated tests must use `httpx.MockTransport`; only the final manual acceptance check may use the live network.
+- Follow red-green-refactor for every behavior change and commit after each coherent task.
+
+---
+
+## Task 1: Add the HTTP dependency and establish the baseline
+
+**Files:**
+
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+
+- [ ] Add `httpx>=0.27,<1` to `[project].dependencies` in `pyproject.toml`.
+- [ ] Synchronize the environment and lock file:
+
+  ```powershell
+  C:\Users\Jonathan Lee\.local\bin\uv.exe sync
+  ```
+
+- [ ] Verify the dependency is the real `httpx` package and record the current regression baseline:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -c "import httpx; print(httpx.__version__)"
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  ```
+
+  Expected baseline: all 15 existing v0.2 tests pass.
+
+- [ ] Commit:
+
+  ```powershell
+  git add pyproject.toml uv.lock
+  git commit -m "Add HTTP client dependency"
+  ```
+
+## Task 2: Implement bounded, safe source-package extraction
+
+**Files:**
+
+- Create: `src/papergraph/archive.py`
+- Create: `tests/test_archive.py`
+
+**Public implementation surface:**
+
+```python
+MAX_ARCHIVE_MEMBERS = 10_000
+MAX_EXTRACTED_BYTES = 500 * 1024 * 1024
+
+class ArchiveError(Exception): ...
+class UnsafeArchiveError(ArchiveError): ...
+class ArchiveLimitError(ArchiveError): ...
+class UnsupportedArchiveError(ArchiveError): ...
+
+def extract_source_package(
+    source: Path,
+    destination: Path,
+    *,
+    max_members: int = MAX_ARCHIVE_MEMBERS,
+    max_bytes: int = MAX_EXTRACTED_BYTES,
+) -> None: ...
+```
+
+- [ ] Write failing tests for a regular tar package and a gzip-compressed tar package. Each test creates the package in `tmp_path`, calls `extract_source_package`, and asserts nested file contents.
+- [ ] Run the focused tests and confirm failure because `papergraph.archive` does not exist:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest tests\test_archive.py -q -p no:cacheprovider
+  ```
+
+- [ ] Implement tar detection with `tarfile.open(..., mode="r:*")` and manual member extraction. Normalize member names as POSIX paths after converting backslashes; reject absolute paths, Windows drive prefixes, `..`, and resolved targets outside `destination`.
+- [ ] Permit only directories and regular files. Reject symbolic links, hard links, devices, FIFOs, and all unknown member types before writing anything from that member.
+- [ ] Count members before extraction and reject `len(members) > max_members`. Sum declared regular-file sizes and reject the archive before extraction if the total exceeds `max_bytes`. During copying, count actual bytes as a second enforcement layer.
+- [ ] Rerun the focused tests and confirm the tar cases pass.
+- [ ] Add failing tests for absolute paths, `../` traversal, backslash traversal, drive-qualified paths, symlinks, hardlinks, special files, excessive member count, excessive declared size, and excessive bytes actually read from a mocked member stream.
+- [ ] Implement the smallest changes required to make every safety test pass. Ensure no rejected path creates content outside `destination`.
+- [ ] Add failing tests for a gzip-compressed single TeX source and a plain single-file TeX response; both must become `destination/main.tex`.
+- [ ] Implement fallback detection: after tar parsing raises `ReadError`, recognize gzip magic and stream-decompress one file, otherwise accept only plausible non-empty TeX text. Apply the extracted-byte limit to both. Reject zip signatures, random binary content, empty bodies, and invalid gzip as `UnsupportedArchiveError`.
+- [ ] Run focused and regression tests:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest tests\test_archive.py -q -p no:cacheprovider
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  ```
+
+- [ ] Commit:
+
+  ```powershell
+  git add src\papergraph\archive.py tests\test_archive.py
+  git commit -m "Add safe arXiv source extraction"
+  ```
+
+## Task 3: Normalize identifiers and stream bounded downloads
+
+**Files:**
+
+- Create: `src/papergraph/arxiv.py`
+- Create: `tests/test_arxiv.py`
+
+**Initial implementation surface:**
+
+```python
+ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
+MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
+
+class ArxivImportError(Exception): ...
+class InvalidArxivIdError(ArxivImportError): ...
+class ArxivDownloadError(ArxivImportError): ...
+class ArxivCacheError(ArxivImportError): ...
+class MainFileSelectionError(ArxivImportError): ...
+
+def normalize_arxiv_id(value: str) -> str: ...
+
+def download_arxiv_source(
+    arxiv_id: str,
+    destination: Path,
+    *,
+    client: httpx.Client | None = None,
+    max_bytes: int = MAX_DOWNLOAD_BYTES,
+) -> None: ...
+```
+
+- [ ] Write parameterized failing tests showing these normalize successfully: `2401.12345`, `2401.12345v2`, `arXiv:2401.12345`, `math/0307200`, and `hep-th/9901001v3`.
+- [ ] Add rejection tests for empty values, URLs, whitespace inside identifiers, `..`, leading slashes, malformed modern IDs, malformed legacy IDs, and version zero.
+- [ ] Run the focused tests to establish red:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest tests\test_arxiv.py -q -p no:cacheprovider
+  ```
+
+- [ ] Implement strict full-match patterns: modern `\d{4}\.\d{4,5}(?:v[1-9]\d*)?` and legacy `[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?`. Strip surrounding whitespace and one case-insensitive `arXiv:` prefix; return a canonical prefix-free identifier.
+- [ ] Write a failing `httpx.MockTransport` test asserting a GET to exactly `https://export.arxiv.org/e-print/{normalized-id}`, redirects enabled, a PaperGraph user agent, streamed body contents, and no request to a caller-provided host.
+- [ ] Implement `download_arxiv_source` with `httpx.Timeout(connect=10, read=60, write=60, pool=10)`. Stream into `destination`, reject non-2xx responses, declared `Content-Length` over the limit, observed bytes over the limit, and empty responses. Delete a partial destination on every failure.
+- [ ] Add failing tests for oversized declared length, oversized streamed body, empty response, HTTP errors, timeout, and connection error. Assert messages identify the normalized paper but do not expose destination paths or response bodies.
+- [ ] Translate `httpx.HTTPError` and validation failures into `ArxivDownloadError`; make all focused tests pass.
+- [ ] Run focused and regression tests, then commit:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest tests\test_arxiv.py -q -p no:cacheprovider
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  git add src\papergraph\arxiv.py tests\test_arxiv.py
+  git commit -m "Add bounded arXiv source downloads"
+  ```
+
+## Task 4: Select and validate a root LaTeX file
+
+**Files:**
+
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `tests/test_arxiv.py`
+
+**New implementation surface:**
+
+```python
+def select_main_file(
+    project_root: Path,
+    main_file: str | None = None,
+) -> Path: ...
+```
+
+- [ ] Write failing tests for: one document candidate; unique preferred `main.tex`, then `paper.tex`, then `manuscript.tex`; ambiguity; no valid candidate; explicit nested override; non-`.tex` override; missing override; absolute override; drive-qualified override; and parent traversal.
+- [ ] Test that commented `\documentclass` or `\begin{document}` does not qualify, while escaped percent signs do not incorrectly hide later commands.
+- [ ] Implement recursive enumeration of non-hidden `.tex` regular files. Inspect only a bounded prefix per file, decode with a documented tolerant strategy, strip LaTeX comments consistently with the loader, and require both root-document commands in uncommented text.
+- [ ] Return an absolute resolved path inside `project_root`. Error messages for ambiguity must list sorted relative candidate paths; the no-candidate error must list discovered `.tex` paths when present.
+- [ ] For explicit overrides, normalize both slash styles, reject absolute/drive/`..` paths before resolution, require containment, a regular file, and a `.tex` suffix.
+- [ ] Run focused and regression tests, then commit:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest tests\test_arxiv.py -q -p no:cacheprovider
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  git add src\papergraph\arxiv.py tests\test_arxiv.py
+  git commit -m "Select arXiv root LaTeX files"
+  ```
+
+## Task 5: Add transactional persistent caching and orchestration
+
+**Files:**
+
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `tests/test_arxiv.py`
+
+**Final orchestration surface:**
+
+```python
+@dataclass(frozen=True, slots=True)
+class ArxivProject:
+    arxiv_id: str
+    project_dir: Path
+    main_file: Path
+    cached: bool
+
+def default_cache_root() -> Path: ...
+
+def prepare_arxiv_project(
+    arxiv_id: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+    *,
+    cache_root: Path | None = None,
+    client: httpx.Client | None = None,
+) -> ArxivProject: ...
+```
+
+- [ ] Write failing tests for platform cache-root precedence: `LOCALAPPDATA`, then `XDG_CACHE_HOME`, then `~/.cache`. Isolate environment variables with `monkeypatch`.
+- [ ] Implement `default_cache_root`. Encode cache directory names deterministically, replacing the slash in legacy IDs with `__` and preserving version suffixes.
+- [ ] Write a failing first-import test using `MockTransport`. Assert download, extraction, main-file selection, a JSON manifest named `.papergraph.json`, and `cached is False`.
+- [ ] Implement preparation in a temporary sibling directory. Store extracted files under the final entry root and a manifest containing only the normalized ID and main-file relative path. Flush/close files before publishing with an atomic rename.
+- [ ] Write a failing cache-hit test that supplies a transport which would fail if called. Validate manifest ID, safe relative main path, existence, regular-file status, suffix, and containment; return `cached is True` without network access.
+- [ ] Write failing tests for `refresh=True`: successful refresh replaces the entry and returns `cached is False`; failed download, extraction, or selection preserves the old valid entry byte-for-byte; temporary siblings are removed.
+- [ ] Implement refresh with an adjacent backup only during the final rename window, restore it if publication fails, and remove it after success. Never delete the valid entry before a replacement is ready.
+- [ ] Write failing tests for corrupt JSON, mismatched IDs, unsafe manifest paths, missing selected files, and invalid entry layout. Treat these as cache misses and rebuild when possible; if rebuilding fails, raise `ArxivCacheError` or the underlying domain error and leave no partial published state.
+- [ ] Test that a `main_file` override is honored for both new imports and valid cache hits. A different valid override may select another root inside the cached project without downloading again.
+- [ ] Translate `ArchiveError` subclasses into safe `ArxivImportError` messages that retain whether the package was unsafe, too large, or unsupported.
+- [ ] Run focused and full tests, then commit:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest tests\test_arxiv.py tests\test_archive.py -q -p no:cacheprovider
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  git add src\papergraph\arxiv.py tests\test_arxiv.py
+  git commit -m "Cache prepared arXiv source projects"
+  ```
+
+## Task 6: Expose arXiv import through MCP without unsafe state swaps
+
+**Files:**
+
+- Modify: `src/papergraph/server.py`
+- Create: `tests/test_server.py`
+
+- [ ] Write a failing test that monkeypatches `prepare_arxiv_project` to return a temporary multi-file project, invokes `load_arxiv_paper`, and asserts normalized ID, selected path, cache flag, node count, kind counts, and availability through the existing graph query functions.
+- [ ] Add the MCP tool:
+
+  ```python
+  @mcp.tool()
+  def load_arxiv_paper(
+      arxiv_id: str,
+      main_file: str | None = None,
+      refresh: bool = False,
+  ) -> dict: ...
+  ```
+
+  Compose `prepare_arxiv_project -> load_latex_project -> parse_latex -> PaperGraph`. Assign `_current_graph` and `_current_path` only after every step succeeds.
+- [ ] Extract a private response/count helper only if it removes duplication with `load_paper`; do not change the existing public response shape of `load_paper`.
+- [ ] Write failing tests proving `ArxivImportError`, loader `OSError`, and loader `ValueError` become `ToolError` with useful messages.
+- [ ] Add a state-preservation test: load a known local graph, force an arXiv failure after preparation, and assert subsequent graph queries still return the original paper.
+- [ ] Update `require_graph` to mention both load tools without breaking its exception type.
+- [ ] Run focused and regression tests, then commit:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest tests\test_server.py -q -p no:cacheprovider
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  git add src\papergraph\server.py tests\test_server.py
+  git commit -m "Expose arXiv paper loading through MCP"
+  ```
+
+## Task 7: Document and version v0.3
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `src/papergraph/__init__.py` only if it currently exposes a version constant
+
+- [ ] Update the package version to `0.3.0` and synchronize the lock file:
+
+  ```powershell
+  C:\Users\Jonathan Lee\.local\bin\uv.exe lock
+  ```
+
+- [ ] Expand the README with `load_arxiv_paper`, accepted ID examples, cache reuse and `refresh`, ambiguous-root recovery with `main_file`, network requirements, fixed arXiv source endpoint, and the 100 MiB/500 MiB/10,000 safety limits.
+- [ ] Keep the local `load_paper` v0.2 documentation intact.
+- [ ] Run the full deterministic suite:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  ```
+
+- [ ] Commit:
+
+  ```powershell
+  git add README.md pyproject.toml uv.lock src\papergraph\__init__.py
+  git commit -m "Document PaperGraph v0.3"
+  ```
+
+  If `src/papergraph/__init__.py` does not contain version metadata and is unchanged, omit it from `git add`.
+
+## Task 8: Final verification and live acceptance
+
+**Files:** No intended source changes. If verification reveals a defect, return to the relevant task, add a regression test first, fix it, and commit that focused correction.
+
+- [ ] Inspect the complete branch diff and confirm it contains no generated archives, cache entries, secrets, local environment changes, or unrelated edits:
+
+  ```powershell
+  git status --short
+  git diff --check origin/main...HEAD
+  git diff --stat origin/main...HEAD
+  ```
+
+- [ ] Run all deterministic tests from a clean process:
+
+  ```powershell
+  .\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+  ```
+
+- [ ] Exercise a local MCP-level smoke test with a `MockTransport` fixture or temporary source package to verify download-to-query behavior without network dependency.
+- [ ] Perform one manual live import using a small stable arXiv identifier and an isolated temporary cache root. Confirm the fixed endpoint returns a supported source package, the root file is selected, and at least the import metadata is returned. If that paper has no theorem environments, successful preparation and graph activation with zero nodes is acceptable; otherwise confirm theorem queries work.
+- [ ] Run the full deterministic suite again after the live check to prove the acceptance action did not affect tests.
+- [ ] Review the implementation against every acceptance criterion in `docs/superpowers/specs/2026-09-02-arxiv-import-design.md`.
+- [ ] Report commits, exact test result, live acceptance result, and any known limitations. Do not merge or push unless the user explicitly asks.

--- a/docs/superpowers/specs/2026-09-02-arxiv-import-design.md
+++ b/docs/superpowers/specs/2026-09-02-arxiv-import-design.md
@@ -1,0 +1,135 @@
+# arXiv Source Import Design
+
+## Goal
+
+Add a dedicated MCP tool that accepts an arXiv identifier, downloads and safely unpacks the paper's source package, selects its root LaTeX file, and loads the resulting theorem dependency graph through the existing PaperGraph pipeline.
+
+## Scope
+
+v0.3 adds arXiv source import only. GitHub Actions, theorem source-line metadata, PDF fallback, and arbitrary URL downloads remain outside this release.
+
+Supported identifiers include:
+
+- Modern identifiers such as `2401.12345` and `2401.12345v2`.
+- Legacy identifiers such as `math/0307200` and `hep-th/9901001v3`.
+- The optional `arXiv:` prefix.
+
+Web URLs are not accepted as identifiers. An unversioned identifier resolves to the latest source returned by arXiv and remains cached until the caller passes `refresh=True`.
+
+## Public MCP interface
+
+Add:
+
+```python
+load_arxiv_paper(
+    arxiv_id: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+) -> dict
+```
+
+The tool returns the normalized arXiv identifier, selected root-file path, whether an existing cache entry was reused, theorem count, and counts by theorem kind. It activates the same in-memory graph used by `list_theorems`, `get_theorem`, `get_dependencies`, and `where_used`.
+
+`load_paper(path)` remains the local-file interface and keeps its current behavior.
+
+## Components and data flow
+
+Add `src/papergraph/arxiv.py` for identifier validation, HTTP download, caching, main-file selection, and project orchestration. Add `src/papergraph/archive.py` for source-package format detection and safe extraction.
+
+```text
+load_arxiv_paper
+  -> normalize_arxiv_id
+  -> fetch source from https://export.arxiv.org/e-print/{id}
+  -> enforce compressed download limit
+  -> safely unpack into a temporary cache entry
+  -> select or validate the main .tex file
+  -> atomically publish the cache entry
+  -> load_latex_project
+  -> parse_latex
+  -> PaperGraph
+```
+
+The server imports this orchestration layer and does not implement network, archive, or cache logic itself.
+
+## HTTP behavior
+
+Declare `httpx>=0.27,<1` as a direct dependency. Download with a 10-second connection timeout, a 60-second read timeout, redirects enabled, and a PaperGraph user agent. Only the fixed arXiv e-print endpoint is constructed; user input never becomes a host, scheme, query, or arbitrary path.
+
+Read the response as a stream. Reject a declared or observed body larger than 100 MiB. Treat non-success responses, timeouts, connection failures, and empty bodies as explicit import errors containing the normalized identifier but no local secrets.
+
+Tests use `httpx.MockTransport`; the normal automated suite never depends on live network access.
+
+## Cache behavior
+
+Use a platform-appropriate per-user cache root:
+
+- `%LOCALAPPDATA%\papergraph\arxiv` on Windows when `LOCALAPPDATA` exists.
+- `$XDG_CACHE_HOME/papergraph/arxiv` when `XDG_CACHE_HOME` exists.
+- `~/.cache/papergraph/arxiv` otherwise.
+
+An optional internal cache-root parameter permits isolated tests without changing the MCP signature. Replace `/` in legacy identifiers with a filesystem-safe separator and keep version suffixes distinct.
+
+Each cache entry contains the extracted project and a small JSON manifest with the normalized identifier and selected main-file relative path. A cache hit validates the manifest and selected file before reuse.
+
+Downloads and extraction occur in a temporary sibling directory. Only a fully downloaded, safely extracted, and unambiguously selected project is renamed into the final cache location. On refresh, the existing valid entry remains usable until the replacement is ready. Failures clean up temporary data and do not publish partial entries.
+
+## Safe archive extraction
+
+Support tar archives, compressed tar archives recognized by Python's `tarfile`, gzip-compressed single-source files, and plain single-file TeX responses.
+
+Before writing an archive member:
+
+- Reject absolute paths, drive-qualified paths, and any path containing `..`.
+- Resolve the destination and require it to remain inside the temporary extraction root.
+- Reject symbolic links, hard links, devices, FIFOs, and other special members.
+- Permit only directories and regular files.
+- Enforce at most 10,000 members.
+- Enforce at most 500 MiB of total declared and actually written content.
+
+Single-file gzip and plain-TeX responses are written as `main.tex` under the same extracted-size limit.
+
+## Main-file selection
+
+If `main_file` is supplied, interpret it relative to the extracted project root. It must remain inside that root, exist as a regular file, and use a `.tex` suffix.
+
+Without an override:
+
+1. Enumerate non-hidden `.tex` files.
+2. Keep files whose uncommented text contains both `\documentclass` and `\begin{document}`.
+3. If exactly one candidate remains, choose it.
+4. If multiple remain, prefer a unique basename in this order: `main.tex`, `paper.tex`, `manuscript.tex`.
+5. If selection is still ambiguous, raise an error listing relative candidate paths.
+6. If no candidate exists, raise an error listing the discovered `.tex` files when available.
+
+Candidate inspection uses bounded text reads so a single unusually large file cannot create an avoidable memory spike.
+
+## Error model
+
+Define focused domain exceptions in `arxiv.py`, rooted at `ArxivImportError`, for invalid identifiers, download failures, unsafe or unsupported archives, cache corruption, and main-file selection failures. `archive.py` raises archive-specific subclasses or errors that `arxiv.py` translates.
+
+The MCP tool converts `ArxivImportError`, loader `OSError`, and loader `ValueError` into `ToolError`. Failed imports do not replace the currently loaded graph.
+
+## Testing
+
+Add unit tests for:
+
+- Modern, versioned, prefixed, and legacy identifier normalization.
+- Invalid identifiers and attempted URL/path input.
+- Correct endpoint construction and streaming through `httpx.MockTransport`.
+- Download size enforcement and HTTP failure translation.
+- Safe tar extraction and rejection of traversal, links, special files, excessive members, and excessive expanded size.
+- Single-file gzip and plain-TeX packages.
+- Unique, preferred-name, ambiguous, missing, and explicitly overridden main-file selection.
+- Cache reuse without a second HTTP request, refresh replacement, invalid manifest handling, and cleanup after failure.
+- MCP activation of a downloaded multi-file project and conversion of import failures to `ToolError`.
+- Regression of all v0.2 local-loading behavior.
+
+After the deterministic suite passes, perform one manual live import of a small stable arXiv source package. The live check is an acceptance command, not a committed test.
+
+## Version and documentation
+
+Update the package version and lockfile to `0.3.0`. Document `load_arxiv_paper`, supported identifier formats, caching, `main_file`, `refresh`, network requirements, and the safety limits in the README.
+
+## Acceptance criteria
+
+v0.3 is complete when a valid arXiv identifier can populate the active PaperGraph from a safely cached source package; ambiguous entry files can be resolved with `main_file`; malicious or excessive archives are rejected without filesystem escape or partial cache state; every deterministic test passes; and one live arXiv import succeeds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Turn mathematical LaTeX papers into theorem dependency graphs for
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "httpx>=0.27,<1",
     "mcp[cli]>=2,<3",
 ]
 

--- a/src/papergraph/archive.py
+++ b/src/papergraph/archive.py
@@ -72,13 +72,11 @@ def _extract_tar(
         return False
 
     with archive:
-        members = archive.getmembers()
-        if len(members) > max_members:
-            raise ArchiveLimitError("Archive contains too many members")
-
         declared_size = 0
         targets: list[tuple[tarfile.TarInfo, Path]] = []
-        for member in members:
+        for index, member in enumerate(archive, start=1):
+            if index > max_members:
+                raise ArchiveLimitError("Archive contains too many members")
             target = _member_target(destination, member.name)
             if member.isdir():
                 targets.append((member, target))

--- a/src/papergraph/archive.py
+++ b/src/papergraph/archive.py
@@ -1,0 +1,182 @@
+"""Safe extraction of arXiv source responses."""
+
+from __future__ import annotations
+
+import gzip
+import re
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+
+MAX_ARCHIVE_MEMBERS = 10_000
+MAX_EXTRACTED_BYTES = 500 * 1024 * 1024
+_COPY_CHUNK_SIZE = 1024 * 1024
+_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
+
+
+class ArchiveError(Exception):
+    """Base error for source-package extraction."""
+
+
+class UnsafeArchiveError(ArchiveError):
+    """The package contains an unsafe path or member type."""
+
+
+class ArchiveLimitError(ArchiveError):
+    """The package exceeds a configured extraction limit."""
+
+
+class UnsupportedArchiveError(ArchiveError):
+    """The response is not a supported arXiv source format."""
+
+
+def _member_target(root: Path, member_name: str) -> Path:
+    normalized = member_name.replace("\\", "/")
+    if normalized.startswith("/") or _DRIVE_PREFIX_RE.match(normalized):
+        raise UnsafeArchiveError(f"Unsafe archive path: {member_name}")
+
+    relative = PurePosixPath(normalized)
+    if ".." in relative.parts:
+        raise UnsafeArchiveError(f"Unsafe archive path: {member_name}")
+
+    target = root.joinpath(*relative.parts).resolve()
+    if not target.is_relative_to(root):
+        raise UnsafeArchiveError(f"Unsafe archive path: {member_name}")
+    return target
+
+
+def _copy_bounded(source, destination: Path, *, remaining: int) -> int:
+    written = 0
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("wb") as output:
+        while chunk := source.read(_COPY_CHUNK_SIZE):
+            written += len(chunk)
+            if written > remaining:
+                raise ArchiveLimitError("Extracted source size exceeds the limit")
+            output.write(chunk)
+    return written
+
+
+def _extract_tar(
+    source: Path,
+    destination: Path,
+    *,
+    max_members: int,
+    max_bytes: int,
+) -> bool:
+    try:
+        archive = tarfile.open(source, mode="r:*")
+    except tarfile.ReadError:
+        return False
+
+    with archive:
+        members = archive.getmembers()
+        if len(members) > max_members:
+            raise ArchiveLimitError("Archive contains too many members")
+
+        declared_size = 0
+        targets: list[tuple[tarfile.TarInfo, Path]] = []
+        for member in members:
+            target = _member_target(destination, member.name)
+            if member.isdir():
+                targets.append((member, target))
+                continue
+            if not member.isfile():
+                raise UnsafeArchiveError(
+                    f"Unsupported archive member type: {member.name}"
+                )
+            if target == destination:
+                raise UnsafeArchiveError(f"Unsafe archive path: {member.name}")
+            declared_size += member.size
+            if declared_size > max_bytes:
+                raise ArchiveLimitError("Extracted source size exceeds the limit")
+            targets.append((member, target))
+
+        written = 0
+        for member, target in targets:
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            member_source = archive.extractfile(member)
+            if member_source is None:
+                raise UnsupportedArchiveError(
+                    f"Could not read archive member: {member.name}"
+                )
+            with member_source:
+                written += _copy_bounded(
+                    member_source,
+                    target,
+                    remaining=max_bytes - written,
+                )
+    return True
+
+
+def _extract_gzip(source: Path, destination: Path, *, max_bytes: int) -> None:
+    try:
+        with gzip.open(source, "rb") as decompressed:
+            _copy_bounded(
+                decompressed,
+                destination / "main.tex",
+                remaining=max_bytes,
+            )
+    except (gzip.BadGzipFile, EOFError, OSError) as exc:
+        raise UnsupportedArchiveError("Invalid gzip source package") from exc
+
+
+def _extract_plain_tex(source: Path, destination: Path, *, max_bytes: int) -> None:
+    size = source.stat().st_size
+    if size > max_bytes:
+        raise ArchiveLimitError("Extracted source size exceeds the limit")
+    payload = source.read_bytes()
+    if not payload or b"\x00" in payload or b"\\" not in payload:
+        raise UnsupportedArchiveError("Response is not a supported source package")
+    try:
+        payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise UnsupportedArchiveError("Response is not a text source package") from exc
+    (destination / "main.tex").write_bytes(payload)
+
+
+def extract_source_package(
+    source: Path,
+    destination: Path,
+    *,
+    max_members: int = MAX_ARCHIVE_MEMBERS,
+    max_bytes: int = MAX_EXTRACTED_BYTES,
+) -> None:
+    """Extract one supported source response without publishing partial data."""
+
+    source = Path(source)
+    destination = Path(destination)
+    if max_members < 1 or max_bytes < 1:
+        raise ValueError("Extraction limits must be positive")
+    if destination.exists():
+        raise FileExistsError(f"Extraction destination already exists: {destination}")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(
+            prefix=f".{destination.name}-",
+            dir=destination.parent,
+        )
+    )
+    try:
+        if not _extract_tar(
+            source,
+            staging,
+            max_members=max_members,
+            max_bytes=max_bytes,
+        ):
+            signature = source.read_bytes()[:4]
+            if signature.startswith(b"\x1f\x8b"):
+                _extract_gzip(source, staging, max_bytes=max_bytes)
+            elif signature.startswith(b"PK\x03\x04"):
+                raise UnsupportedArchiveError("Zip source packages are not supported")
+            else:
+                _extract_plain_tex(source, staging, max_bytes=max_bytes)
+        staging.rename(destination)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import shutil
+import tempfile
+import uuid
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 import httpx
 
+from papergraph.archive import (
+    ArchiveError,
+    ArchiveLimitError,
+    UnsafeArchiveError,
+    UnsupportedArchiveError,
+    extract_source_package,
+)
 from papergraph.loader import _is_commented
 
 
@@ -43,6 +56,18 @@ class ArxivCacheError(ArxivImportError):
 
 class MainFileSelectionError(ArxivImportError):
     """A root LaTeX document could not be selected."""
+
+
+class ArxivArchiveError(ArxivImportError):
+    """The downloaded source package cannot be extracted safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ArxivProject:
+    arxiv_id: str
+    project_dir: Path
+    main_file: Path
+    cached: bool
 
 
 def normalize_arxiv_id(value: str) -> str:
@@ -229,3 +254,135 @@ def select_main_file(
     else:
         detail = " No .tex files were discovered."
     raise MainFileSelectionError(f"No root LaTeX file found.{detail}")
+
+
+def default_cache_root() -> Path:
+    """Return the platform-appropriate persistent PaperGraph cache root."""
+
+    if local_app_data := os.environ.get("LOCALAPPDATA"):
+        return Path(local_app_data) / "papergraph" / "arxiv"
+    if xdg_cache_home := os.environ.get("XDG_CACHE_HOME"):
+        return Path(xdg_cache_home) / "papergraph" / "arxiv"
+    return Path.home() / ".cache" / "papergraph" / "arxiv"
+
+
+def _cache_key(arxiv_id: str) -> str:
+    return arxiv_id.replace("/", "__")
+
+
+def _read_cached_main(entry: Path, arxiv_id: str) -> Path | None:
+    manifest_path = entry / ".papergraph.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(manifest, dict) or manifest.get("arxiv_id") != arxiv_id:
+            return None
+        stored_main = manifest.get("main_file")
+        if not isinstance(stored_main, str):
+            return None
+        return select_main_file(entry, stored_main)
+    except (OSError, json.JSONDecodeError, MainFileSelectionError):
+        return None
+
+
+def _translate_archive_error(arxiv_id: str, error: ArchiveError) -> ArxivArchiveError:
+    if isinstance(error, UnsafeArchiveError):
+        reason = "contains unsafe archive content"
+    elif isinstance(error, ArchiveLimitError):
+        reason = "exceeds archive safety limits"
+    elif isinstance(error, UnsupportedArchiveError):
+        reason = "uses an unsupported source format"
+    else:
+        reason = "could not be extracted"
+    return ArxivArchiveError(f"arXiv source for {arxiv_id} {reason}")
+
+
+def _remove_cache_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def _publish_cache_entry(project: Path, entry: Path) -> None:
+    backup: Path | None = None
+    if entry.exists():
+        backup = entry.parent / f".{entry.name}.backup-{uuid.uuid4().hex}"
+        entry.rename(backup)
+    try:
+        project.rename(entry)
+    except Exception:
+        if backup is not None and backup.exists() and not entry.exists():
+            backup.rename(entry)
+        raise
+    else:
+        if backup is not None:
+            _remove_cache_path(backup)
+
+
+def prepare_arxiv_project(
+    arxiv_id: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+    *,
+    cache_root: Path | None = None,
+    client: httpx.Client | None = None,
+) -> ArxivProject:
+    """Download, safely extract, select, and cache one arXiv source project."""
+
+    normalized_id = normalize_arxiv_id(arxiv_id)
+    root = Path(cache_root) if cache_root is not None else default_cache_root()
+    root = root.expanduser().resolve()
+    entry = root / _cache_key(normalized_id)
+
+    cached_main = _read_cached_main(entry, normalized_id)
+    if cached_main is not None and not refresh:
+        selected = select_main_file(entry, main_file) if main_file else cached_main
+        return ArxivProject(normalized_id, entry, selected, True)
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        work = Path(
+            tempfile.mkdtemp(
+                prefix=f".{entry.name}-",
+                dir=root,
+            )
+        )
+    except OSError as exc:
+        raise ArxivCacheError(
+            f"Could not create the arXiv cache for {normalized_id}"
+        ) from exc
+
+    try:
+        source = work / "source-package"
+        project = work / "project"
+        download_arxiv_source(normalized_id, source, client=client)
+        try:
+            extract_source_package(source, project)
+        except ArchiveError as exc:
+            raise _translate_archive_error(normalized_id, exc) from exc
+
+        selected = select_main_file(project, main_file)
+        selected_relative = selected.relative_to(project).as_posix()
+        manifest = {
+            "arxiv_id": normalized_id,
+            "main_file": selected_relative,
+        }
+        (project / ".papergraph.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _publish_cache_entry(project, entry)
+        return ArxivProject(
+            normalized_id,
+            entry,
+            entry.joinpath(*PurePosixPath(selected_relative).parts),
+            False,
+        )
+    except ArxivImportError:
+        raise
+    except OSError as exc:
+        raise ArxivCacheError(
+            f"Could not update the arXiv cache for {normalized_id}"
+        ) from exc
+    finally:
+        shutil.rmtree(work, ignore_errors=True)

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -1,0 +1,137 @@
+"""Download and prepare arXiv source projects."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import httpx
+
+
+ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
+MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
+_USER_AGENT = "PaperGraph/0.3 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
+_LEGACY_ID_RE = re.compile(
+    r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"
+)
+_HTTP_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=60.0, pool=10.0)
+
+
+class ArxivImportError(Exception):
+    """Base error for arXiv imports."""
+
+
+class InvalidArxivIdError(ArxivImportError):
+    """The caller supplied an unsupported arXiv identifier."""
+
+
+class ArxivDownloadError(ArxivImportError):
+    """The arXiv source response could not be downloaded safely."""
+
+
+class ArxivCacheError(ArxivImportError):
+    """A persistent source cache entry is invalid or unavailable."""
+
+
+class MainFileSelectionError(ArxivImportError):
+    """A root LaTeX document could not be selected."""
+
+
+def normalize_arxiv_id(value: str) -> str:
+    """Validate and return an arXiv identifier without its optional prefix."""
+
+    if not isinstance(value, str):
+        raise InvalidArxivIdError("arXiv identifier must be text")
+    normalized = value.strip()
+    if normalized[:6].lower() == "arxiv:":
+        normalized = normalized[6:]
+    if not (
+        _MODERN_ID_RE.fullmatch(normalized)
+        or _LEGACY_ID_RE.fullmatch(normalized)
+    ):
+        raise InvalidArxivIdError(f"Invalid arXiv identifier: {value!r}")
+    return normalized
+
+
+def _write_response(
+    response: httpx.Response,
+    destination: Path,
+    *,
+    arxiv_id: str,
+    max_bytes: int,
+) -> None:
+    if not response.is_success:
+        raise ArxivDownloadError(
+            f"arXiv source download failed for {arxiv_id} "
+            f"with HTTP {response.status_code}"
+        )
+
+    declared_length = response.headers.get("content-length")
+    if declared_length is not None:
+        try:
+            declared_bytes = int(declared_length)
+        except ValueError as exc:
+            raise ArxivDownloadError(
+                f"arXiv returned an invalid source length for {arxiv_id}"
+            ) from exc
+        if declared_bytes > max_bytes:
+            raise ArxivDownloadError(
+                f"arXiv source for {arxiv_id} exceeds the download size limit"
+            )
+
+    received = 0
+    with destination.open("wb") as output:
+        for chunk in response.iter_bytes():
+            received += len(chunk)
+            if received > max_bytes:
+                raise ArxivDownloadError(
+                    f"arXiv source for {arxiv_id} exceeds the download size limit"
+                )
+            output.write(chunk)
+    if received == 0:
+        raise ArxivDownloadError(f"arXiv returned an empty source for {arxiv_id}")
+
+
+def download_arxiv_source(
+    arxiv_id: str,
+    destination: Path,
+    *,
+    client: httpx.Client | None = None,
+    max_bytes: int = MAX_DOWNLOAD_BYTES,
+) -> None:
+    """Stream one source response from arXiv's fixed e-print endpoint."""
+
+    normalized_id = normalize_arxiv_id(arxiv_id)
+    if max_bytes < 1:
+        raise ValueError("Download size limit must be positive")
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    url = f"{ARXIV_SOURCE_BASE}/{normalized_id}"
+    owned_client = client is None
+    active_client = client or httpx.Client()
+    try:
+        with active_client.stream(
+            "GET",
+            url,
+            headers={"User-Agent": _USER_AGENT},
+            follow_redirects=True,
+            timeout=_HTTP_TIMEOUT,
+        ) as response:
+            _write_response(
+                response,
+                destination,
+                arxiv_id=normalized_id,
+                max_bytes=max_bytes,
+            )
+    except ArxivDownloadError:
+        destination.unlink(missing_ok=True)
+        raise
+    except httpx.HTTPError as exc:
+        destination.unlink(missing_ok=True)
+        raise ArxivDownloadError(
+            f"Could not download arXiv source for {normalized_id}"
+        ) from exc
+    finally:
+        if owned_client:
+            active_client.close()

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import httpx
+
+from papergraph.loader import _is_commented
 
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
@@ -16,6 +18,11 @@ _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"
 )
 _HTTP_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=60.0, pool=10.0)
+_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
+_ROOT_COMMAND_READ_LIMIT = 1024 * 1024
+_DOCUMENTCLASS_RE = re.compile(r"\\documentclass\b")
+_BEGIN_DOCUMENT_RE = re.compile(r"\\begin\s*\{document\}")
+_PREFERRED_MAIN_NAMES = ("main.tex", "paper.tex", "manuscript.tex")
 
 
 class ArxivImportError(Exception):
@@ -135,3 +142,90 @@ def download_arxiv_source(
     finally:
         if owned_client:
             active_client.close()
+
+
+def _safe_relative_path(value: str) -> PurePosixPath:
+    normalized = value.replace("\\", "/")
+    if normalized.startswith("/") or _DRIVE_PREFIX_RE.match(normalized):
+        raise MainFileSelectionError(f"Unsafe main_file path: {value}")
+    relative = PurePosixPath(normalized)
+    if not normalized or ".." in relative.parts:
+        raise MainFileSelectionError(f"Unsafe main_file path: {value}")
+    return relative
+
+
+def _is_regular_file(path: Path) -> bool:
+    return path.is_file() and not path.is_symlink()
+
+
+def _has_uncommented_match(pattern: re.Pattern[str], text: str) -> bool:
+    return any(not _is_commented(text, match.start()) for match in pattern.finditer(text))
+
+
+def _is_root_document(path: Path) -> bool:
+    with path.open("rb") as source:
+        text = source.read(_ROOT_COMMAND_READ_LIMIT).decode(
+            "utf-8",
+            errors="replace",
+        )
+    return _has_uncommented_match(
+        _DOCUMENTCLASS_RE,
+        text,
+    ) and _has_uncommented_match(_BEGIN_DOCUMENT_RE, text)
+
+
+def _display_paths(root: Path, paths: list[Path]) -> str:
+    return ", ".join(
+        sorted(path.relative_to(root).as_posix() for path in paths)
+    )
+
+
+def select_main_file(
+    project_root: Path,
+    main_file: str | None = None,
+) -> Path:
+    """Select or validate the root LaTeX file in an extracted project."""
+
+    root = Path(project_root).resolve()
+    if not root.is_dir():
+        raise MainFileSelectionError("Extracted arXiv project is not a directory")
+
+    if main_file is not None:
+        relative = _safe_relative_path(main_file)
+        if relative.suffix.lower() != ".tex":
+            raise MainFileSelectionError("main_file must name a .tex file")
+        selected = root.joinpath(*relative.parts).resolve()
+        if not selected.is_relative_to(root) or not _is_regular_file(selected):
+            raise MainFileSelectionError(f"main_file does not exist: {main_file}")
+        return selected
+
+    tex_files: list[Path] = []
+    for path in root.rglob("*.tex"):
+        relative = path.relative_to(root)
+        if any(part.startswith(".") for part in relative.parts):
+            continue
+        resolved = path.resolve()
+        if resolved.is_relative_to(root) and _is_regular_file(path):
+            tex_files.append(resolved)
+
+    candidates = [path for path in tex_files if _is_root_document(path)]
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        for preferred in _PREFERRED_MAIN_NAMES:
+            matches = [
+                path for path in candidates if path.name.lower() == preferred
+            ]
+            if len(matches) == 1:
+                return matches[0]
+        raise MainFileSelectionError(
+            "Multiple root LaTeX files found: "
+            f"{_display_paths(root, candidates)}. "
+            "Pass main_file to choose one."
+        )
+
+    if tex_files:
+        detail = f" Discovered: {_display_paths(root, tex_files)}."
+    else:
+        detail = " No .tex files were discovered."
+    raise MainFileSelectionError(f"No root LaTeX file found.{detail}")

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -271,6 +271,8 @@ def _cache_key(arxiv_id: str) -> str:
 
 
 def _read_cached_main(entry: Path, arxiv_id: str) -> Path | None:
+    if not entry.is_dir() or entry.is_symlink():
+        return None
     manifest_path = entry / ".papergraph.json"
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from mcp.server import MCPServer
 from mcp.server.mcpserver.exceptions import ToolError
 
+from papergraph.arxiv import ArxivImportError, prepare_arxiv_project
 from papergraph.graph import PaperGraph
 from papergraph.loader import load_latex_project
 from papergraph.parser import parse_latex
@@ -19,7 +20,7 @@ def require_graph() -> PaperGraph:
     if _current_graph is None:
         raise ToolError(
             "No paper is loaded. "
-            "Call load_paper(path) first."
+            "Call load_paper(path) or load_arxiv_paper(arxiv_id) first."
         )
 
     return _current_graph
@@ -68,6 +69,46 @@ def load_paper(path: str) -> dict:
 
     return {
         "path": str(paper_path),
+        "nodes": len(nodes),
+        "kinds": kinds,
+    }
+
+
+@mcp.tool()
+def load_arxiv_paper(
+    arxiv_id: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+) -> dict:
+    """Download an arXiv source project and build its theorem graph."""
+
+    global _current_graph
+    global _current_path
+
+    try:
+        project = prepare_arxiv_project(
+            arxiv_id,
+            main_file,
+            refresh,
+        )
+        text = load_latex_project(project.main_file)
+    except (ArxivImportError, OSError, ValueError) as exc:
+        raise ToolError(str(exc)) from exc
+
+    nodes = parse_latex(text)
+    graph = PaperGraph(nodes)
+
+    kinds: dict[str, int] = {}
+    for node in nodes:
+        kinds[node.kind] = kinds.get(node.kind, 0) + 1
+
+    _current_graph = graph
+    _current_path = project.main_file
+
+    return {
+        "arxiv_id": project.arxiv_id,
+        "path": str(project.main_file),
+        "cached": project.cached,
         "nodes": len(nodes),
         "kinds": kinds,
     }

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,173 @@
+import gzip
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from papergraph.archive import (
+    ArchiveLimitError,
+    UnsupportedArchiveError,
+    UnsafeArchiveError,
+    extract_source_package,
+)
+
+
+def make_tar(
+    path: Path,
+    members: list[tuple[tarfile.TarInfo, bytes]],
+    mode: str = "w",
+) -> None:
+    with tarfile.open(path, mode) as archive:
+        for info, content in members:
+            archive.addfile(info, io.BytesIO(content) if info.isfile() else None)
+
+
+def regular_member(name: str, content: bytes) -> tuple[tarfile.TarInfo, bytes]:
+    info = tarfile.TarInfo(name)
+    info.size = len(content)
+    return info, content
+
+
+@pytest.mark.parametrize("mode,suffix", [("w", ".tar"), ("w:gz", ".tar.gz")])
+def test_extracts_tar_sources(
+    tmp_path: Path,
+    mode: str,
+    suffix: str,
+):
+    source = tmp_path / f"source{suffix}"
+    destination = tmp_path / "project"
+    make_tar(
+        source,
+        [
+            regular_member("main.tex", b"MAIN"),
+            regular_member("sections/proof.tex", b"PROOF"),
+        ],
+        mode,
+    )
+
+    extract_source_package(source, destination)
+
+    assert (destination / "main.tex").read_bytes() == b"MAIN"
+    assert (destination / "sections" / "proof.tex").read_bytes() == b"PROOF"
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "/absolute.tex",
+        "../escape.tex",
+        "nested/../../escape.tex",
+        "..\\escape.tex",
+        "C:/escape.tex",
+        "C:\\escape.tex",
+    ],
+)
+def test_rejects_unsafe_tar_paths(tmp_path: Path, member_name: str):
+    source = tmp_path / "source.tar"
+    destination = tmp_path / "project"
+    make_tar(source, [regular_member(member_name, b"BAD")])
+
+    with pytest.raises(UnsafeArchiveError):
+        extract_source_package(source, destination)
+
+    assert not (tmp_path / "escape.tex").exists()
+
+
+@pytest.mark.parametrize(
+    "member_type",
+    [tarfile.SYMTYPE, tarfile.LNKTYPE, tarfile.FIFOTYPE, tarfile.CHRTYPE],
+)
+def test_rejects_links_and_special_members(
+    tmp_path: Path,
+    member_type: bytes,
+):
+    source = tmp_path / "source.tar"
+    destination = tmp_path / "project"
+    info = tarfile.TarInfo("unsafe")
+    info.type = member_type
+    info.linkname = "main.tex"
+    make_tar(source, [(info, b"")])
+
+    with pytest.raises(UnsafeArchiveError):
+        extract_source_package(source, destination)
+
+
+def test_enforces_member_limit(tmp_path: Path):
+    source = tmp_path / "source.tar"
+    destination = tmp_path / "project"
+    make_tar(
+        source,
+        [regular_member(f"{index}.tex", b"x") for index in range(3)],
+    )
+
+    with pytest.raises(ArchiveLimitError, match="members"):
+        extract_source_package(source, destination, max_members=2)
+
+
+def test_enforces_extracted_size_limit(tmp_path: Path):
+    source = tmp_path / "source.tar"
+    destination = tmp_path / "project"
+    make_tar(source, [regular_member("main.tex", b"12345")])
+
+    with pytest.raises(ArchiveLimitError, match="size"):
+        extract_source_package(source, destination, max_bytes=4)
+
+
+def test_extracts_single_file_gzip_as_main_tex(tmp_path: Path):
+    source = tmp_path / "source.gz"
+    destination = tmp_path / "project"
+    source.write_bytes(gzip.compress(b"\\documentclass{article}"))
+
+    extract_source_package(source, destination)
+
+    assert (destination / "main.tex").read_bytes() == b"\\documentclass{article}"
+
+
+def test_extracts_plain_tex_as_main_tex(tmp_path: Path):
+    source = tmp_path / "source"
+    destination = tmp_path / "project"
+    source.write_bytes(b"\\documentclass{article}\n\\begin{document}\nHello")
+
+    extract_source_package(source, destination)
+
+    assert (destination / "main.tex").read_bytes() == source.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [b"", b"PK\x03\x04not-a-supported-zip", b"\x00\x01\x02binary"],
+)
+def test_rejects_unsupported_source_packages(tmp_path: Path, payload: bytes):
+    source = tmp_path / "source"
+    destination = tmp_path / "project"
+    source.write_bytes(payload)
+
+    with pytest.raises(UnsupportedArchiveError):
+        extract_source_package(source, destination)
+
+
+def test_enforces_single_file_gzip_size_limit(tmp_path: Path):
+    source = tmp_path / "source.gz"
+    destination = tmp_path / "project"
+    source.write_bytes(gzip.compress(b"\\documentclass{article}"))
+
+    with pytest.raises(ArchiveLimitError, match="size"):
+        extract_source_package(source, destination, max_bytes=5)
+
+
+def test_failure_does_not_leave_partial_destination(tmp_path: Path):
+    source = tmp_path / "source.tar"
+    destination = tmp_path / "project"
+    make_tar(
+        source,
+        [
+            regular_member("safe.tex", b"SAFE"),
+            regular_member("../escape.tex", b"BAD"),
+        ],
+    )
+
+    with pytest.raises(UnsafeArchiveError):
+        extract_source_package(source, destination)
+
+    assert not destination.exists()

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -6,8 +6,10 @@ import pytest
 from papergraph.arxiv import (
     ArxivDownloadError,
     InvalidArxivIdError,
+    MainFileSelectionError,
     download_arxiv_source,
     normalize_arxiv_id,
+    select_main_file,
 )
 
 
@@ -146,3 +148,122 @@ def test_download_translates_network_failures(
     assert "private network detail" not in message
     assert str(destination) not in message
     assert not destination.exists()
+
+
+def write_tex(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def document_text(body: str = "") -> str:
+    return f"\\documentclass{{article}}\n\\begin{{document}}\n{body}"
+
+
+def test_selects_only_root_document(tmp_path: Path):
+    root = tmp_path / "project"
+    expected = write_tex(root / "article.tex", document_text())
+    write_tex(root / "section.tex", "Section only")
+
+    assert select_main_file(root) == expected.resolve()
+
+
+@pytest.mark.parametrize(
+    ("names", "expected"),
+    [
+        (["draft.tex", "main.tex", "paper.tex"], "main.tex"),
+        (["draft.tex", "paper.tex", "manuscript.tex"], "paper.tex"),
+        (["draft.tex", "manuscript.tex"], "manuscript.tex"),
+    ],
+)
+def test_prefers_conventional_unique_basename(
+    tmp_path: Path,
+    names: list[str],
+    expected: str,
+):
+    root = tmp_path / "project"
+    for name in names:
+        write_tex(root / name, document_text(name))
+
+    assert select_main_file(root) == (root / expected).resolve()
+
+
+def test_reports_sorted_ambiguous_candidates(tmp_path: Path):
+    root = tmp_path / "project"
+    write_tex(root / "zeta.tex", document_text())
+    write_tex(root / "parts" / "alpha.tex", document_text())
+
+    with pytest.raises(MainFileSelectionError) as caught:
+        select_main_file(root)
+
+    message = str(caught.value)
+    assert "parts/alpha.tex" in message
+    assert "zeta.tex" in message
+    assert message.index("parts/alpha.tex") < message.index("zeta.tex")
+
+
+def test_reports_discovered_tex_files_when_no_candidate(tmp_path: Path):
+    root = tmp_path / "project"
+    write_tex(root / "sections" / "body.tex", "Body")
+
+    with pytest.raises(MainFileSelectionError, match="sections/body.tex"):
+        select_main_file(root)
+
+
+def test_ignores_hidden_tex_candidates(tmp_path: Path):
+    root = tmp_path / "project"
+    expected = write_tex(root / "visible.tex", document_text())
+    write_tex(root / ".hidden" / "main.tex", document_text())
+
+    assert select_main_file(root) == expected.resolve()
+
+
+def test_ignores_commented_root_commands(tmp_path: Path):
+    root = tmp_path / "project"
+    write_tex(
+        root / "commented.tex",
+        "% \\documentclass{article}\n% \\begin{document}\n",
+    )
+
+    with pytest.raises(MainFileSelectionError):
+        select_main_file(root)
+
+
+def test_escaped_percent_does_not_hide_root_commands(tmp_path: Path):
+    root = tmp_path / "project"
+    expected = write_tex(
+        root / "main.tex",
+        "\\% literal \\documentclass{article}\n\\begin{document}",
+    )
+
+    assert select_main_file(root) == expected.resolve()
+
+
+@pytest.mark.parametrize("override", ["sections/root.tex", "sections\\root.tex"])
+def test_accepts_safe_explicit_main_file(tmp_path: Path, override: str):
+    root = tmp_path / "project"
+    expected = write_tex(root / "sections" / "root.tex", "custom root")
+
+    assert select_main_file(root, override) == expected.resolve()
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        "missing.tex",
+        "notes.txt",
+        "../outside.tex",
+        "nested/../../outside.tex",
+        "/absolute.tex",
+        "C:/absolute.tex",
+        "C:\\absolute.tex",
+    ],
+)
+def test_rejects_invalid_explicit_main_file(tmp_path: Path, override: str):
+    root = tmp_path / "project"
+    root.mkdir()
+    write_tex(tmp_path / "outside.tex", document_text())
+    write_tex(root / "notes.txt", "notes")
+
+    with pytest.raises(MainFileSelectionError):
+        select_main_file(root, override)

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+
+import httpx
+import pytest
+
+from papergraph.arxiv import (
+    ArxivDownloadError,
+    InvalidArxivIdError,
+    download_arxiv_source,
+    normalize_arxiv_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2401.12345", "2401.12345"),
+        ("2401.12345v2", "2401.12345v2"),
+        (" arXiv:2401.12345 ", "2401.12345"),
+        ("ARXIV:math/0307200", "math/0307200"),
+        ("hep-th/9901001v3", "hep-th/9901001v3"),
+    ],
+)
+def test_normalizes_supported_arxiv_ids(value: str, expected: str):
+    assert normalize_arxiv_id(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "   ",
+        "https://arxiv.org/abs/2401.12345",
+        "2401. 12345",
+        "../2401.12345",
+        "/2401.12345",
+        "2401.123",
+        "2401.123456",
+        "2401.12345v0",
+        "math/030720",
+        "math//0307200",
+        "arXiv:arXiv:2401.12345",
+    ],
+)
+def test_rejects_invalid_arxiv_ids(value: str):
+    with pytest.raises(InvalidArxivIdError):
+        normalize_arxiv_id(value)
+
+
+def test_download_uses_fixed_endpoint_headers_redirects_and_streaming(
+    tmp_path: Path,
+):
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(302, headers={"Location": "/e-print/2401.12345/source"})
+        return httpx.Response(200, content=b"source body")
+
+    destination = tmp_path / "source"
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        download_arxiv_source("arXiv:2401.12345", destination, client=client)
+
+    assert [str(request.url) for request in requests] == [
+        "https://export.arxiv.org/e-print/2401.12345",
+        "https://export.arxiv.org/e-print/2401.12345/source",
+    ]
+    assert requests[0].headers["user-agent"].startswith("PaperGraph/")
+    assert destination.read_bytes() == b"source body"
+
+
+def test_download_rejects_declared_oversize(tmp_path: Path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"Content-Length": "6"}, content=b"123456")
+
+    destination = tmp_path / "source"
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ArxivDownloadError, match="1001.00001"):
+            download_arxiv_source(
+                "1001.00001",
+                destination,
+                client=client,
+                max_bytes=5,
+            )
+
+    assert not destination.exists()
+
+
+def test_download_rejects_observed_oversize(tmp_path: Path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"123456")
+
+    destination = tmp_path / "source"
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ArxivDownloadError, match="size limit"):
+            download_arxiv_source(
+                "1001.00001",
+                destination,
+                client=client,
+                max_bytes=5,
+            )
+
+    assert not destination.exists()
+
+
+def test_download_rejects_empty_response(tmp_path: Path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ArxivDownloadError, match="empty"):
+            download_arxiv_source("1001.00001", tmp_path / "source", client=client)
+
+
+def test_download_translates_http_status_without_response_body(tmp_path: Path):
+    secret = "server-secret-that-must-not-leak"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text=secret)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ArxivDownloadError) as caught:
+            download_arxiv_source("1001.00001", tmp_path / "source", client=client)
+
+    assert "1001.00001" in str(caught.value)
+    assert secret not in str(caught.value)
+
+
+@pytest.mark.parametrize("error_type", [httpx.ReadTimeout, httpx.ConnectError])
+def test_download_translates_network_failures(
+    tmp_path: Path,
+    error_type: type[httpx.HTTPError],
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise error_type("private network detail", request=request)
+
+    destination = tmp_path / "private" / "source"
+    destination.parent.mkdir()
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ArxivDownloadError) as caught:
+            download_arxiv_source("1001.00001", destination, client=client)
+
+    message = str(caught.value)
+    assert "1001.00001" in message
+    assert "private network detail" not in message
+    assert str(destination) not in message
+    assert not destination.exists()

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,14 +1,20 @@
+import io
+import json
+import tarfile
 from pathlib import Path
 
 import httpx
 import pytest
 
 from papergraph.arxiv import (
+    ArxivImportError,
     ArxivDownloadError,
     InvalidArxivIdError,
     MainFileSelectionError,
+    default_cache_root,
     download_arxiv_source,
     normalize_arxiv_id,
+    prepare_arxiv_project,
     select_main_file,
 )
 
@@ -267,3 +273,241 @@ def test_rejects_invalid_explicit_main_file(tmp_path: Path, override: str):
 
     with pytest.raises(MainFileSelectionError):
         select_main_file(root, override)
+
+
+def source_tar(files: dict[str, str]) -> bytes:
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w") as archive:
+        for name, content in files.items():
+            encoded = content.encode("utf-8")
+            info = tarfile.TarInfo(name)
+            info.size = len(encoded)
+            archive.addfile(info, io.BytesIO(encoded))
+    return payload.getvalue()
+
+
+def test_default_cache_root_precedence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    local = tmp_path / "local"
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv("LOCALAPPDATA", str(local))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(xdg))
+    assert default_cache_root() == local / "papergraph" / "arxiv"
+
+    monkeypatch.delenv("LOCALAPPDATA")
+    assert default_cache_root() == xdg / "papergraph" / "arxiv"
+
+    monkeypatch.delenv("XDG_CACHE_HOME")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    assert default_cache_root() == tmp_path / "home" / ".cache" / "papergraph" / "arxiv"
+
+
+def test_prepares_and_manifests_arxiv_project(tmp_path: Path):
+    payload = source_tar(
+        {
+            "main.tex": document_text("\\input{sections/proof}"),
+            "sections/proof.tex": "Proof",
+        }
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=payload)
+
+    cache_root = tmp_path / "cache"
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        project = prepare_arxiv_project(
+            "arXiv:2401.12345",
+            cache_root=cache_root,
+            client=client,
+        )
+
+    assert project.arxiv_id == "2401.12345"
+    assert project.project_dir == cache_root / "2401.12345"
+    assert project.main_file == project.project_dir / "main.tex"
+    assert project.cached is False
+    assert (project.project_dir / "sections" / "proof.tex").read_text() == "Proof"
+    assert json.loads((project.project_dir / ".papergraph.json").read_text()) == {
+        "arxiv_id": "2401.12345",
+        "main_file": "main.tex",
+    }
+
+
+def test_cache_hit_avoids_second_download(tmp_path: Path):
+    calls = 0
+    payload = source_tar({"main.tex": document_text()})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise AssertionError("cache hit attempted a network request")
+        return httpx.Response(200, content=payload)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        first = prepare_arxiv_project("2401.12345", cache_root=tmp_path, client=client)
+        second = prepare_arxiv_project("2401.12345", cache_root=tmp_path, client=client)
+
+    assert first.cached is False
+    assert second.cached is True
+    assert second.main_file == first.main_file
+    assert calls == 1
+
+
+def test_legacy_id_uses_filesystem_safe_cache_name(tmp_path: Path):
+    payload = source_tar({"main.tex": document_text()})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=payload)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        project = prepare_arxiv_project(
+            "math/0307200",
+            cache_root=tmp_path,
+            client=client,
+        )
+
+    assert project.project_dir.name == "math__0307200"
+
+
+def test_successful_refresh_replaces_cache(tmp_path: Path):
+    payloads = iter(
+        [
+            source_tar({"main.tex": document_text("OLD")}),
+            source_tar({"main.tex": document_text("NEW")}),
+        ]
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=next(payloads))
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        prepare_arxiv_project("2401.12345", cache_root=tmp_path, client=client)
+        refreshed = prepare_arxiv_project(
+            "2401.12345",
+            refresh=True,
+            cache_root=tmp_path,
+            client=client,
+        )
+
+    assert refreshed.cached is False
+    assert "NEW" in refreshed.main_file.read_text()
+    assert "OLD" not in refreshed.main_file.read_text()
+
+
+def test_failed_refresh_preserves_valid_cache_and_cleans_temporary_data(
+    tmp_path: Path,
+):
+    calls = 0
+    original = source_tar({"main.tex": document_text("ORIGINAL")})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(200, content=original)
+        return httpx.Response(503, text="failure")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        project = prepare_arxiv_project("2401.12345", cache_root=tmp_path, client=client)
+        before = project.main_file.read_bytes()
+        with pytest.raises(ArxivDownloadError):
+            prepare_arxiv_project(
+                "2401.12345",
+                refresh=True,
+                cache_root=tmp_path,
+                client=client,
+            )
+
+    assert project.main_file.read_bytes() == before
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["2401.12345"]
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        "not json",
+        json.dumps({"arxiv_id": "9999.99999", "main_file": "main.tex"}),
+        json.dumps({"arxiv_id": "2401.12345", "main_file": "../escape.tex"}),
+        json.dumps({"arxiv_id": "2401.12345", "main_file": "missing.tex"}),
+    ],
+)
+def test_invalid_manifest_is_rebuilt(tmp_path: Path, manifest: str):
+    entry = tmp_path / "2401.12345"
+    entry.mkdir()
+    (entry / "main.tex").write_text(document_text("STALE"))
+    (entry / ".papergraph.json").write_text(manifest)
+    payload = source_tar({"main.tex": document_text("FRESH")})
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, content=payload)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        project = prepare_arxiv_project("2401.12345", cache_root=tmp_path, client=client)
+
+    assert calls == 1
+    assert project.cached is False
+    assert "FRESH" in project.main_file.read_text()
+
+
+def test_non_directory_cache_entry_is_rebuilt(tmp_path: Path):
+    (tmp_path / "2401.12345").write_text("invalid entry")
+    payload = source_tar({"main.tex": document_text("FRESH")})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=payload)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        project = prepare_arxiv_project("2401.12345", cache_root=tmp_path, client=client)
+
+    assert project.project_dir.is_dir()
+    assert "FRESH" in project.main_file.read_text()
+
+
+def test_main_file_override_can_change_on_cache_hit(tmp_path: Path):
+    payload = source_tar(
+        {
+            "first.tex": document_text("FIRST"),
+            "nested/second.tex": document_text("SECOND"),
+        }
+    )
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, content=payload)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        first = prepare_arxiv_project(
+            "2401.12345",
+            main_file="first.tex",
+            cache_root=tmp_path,
+            client=client,
+        )
+        second = prepare_arxiv_project(
+            "2401.12345",
+            main_file="nested/second.tex",
+            cache_root=tmp_path,
+            client=client,
+        )
+
+    assert first.main_file.name == "first.tex"
+    assert second.main_file.name == "second.tex"
+    assert second.cached is True
+    assert calls == 1
+
+
+def test_unsafe_archive_is_translated_and_not_published(tmp_path: Path):
+    payload = source_tar({"../escape.tex": "BAD"})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=payload)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ArxivImportError, match="unsafe"):
+            prepare_arxiv_project("2401.12345", cache_root=tmp_path, client=client)
+
+    assert not (tmp_path / "2401.12345").exists()
+    assert not (tmp_path.parent / "escape.tex").exists()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+
+import papergraph.server as server
+from papergraph.arxiv import ArxivDownloadError, ArxivProject
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    previous_graph = server._current_graph
+    previous_path = server._current_path
+    server._current_graph = None
+    server._current_path = None
+    try:
+        yield
+    finally:
+        server._current_graph = previous_graph
+        server._current_path = previous_path
+
+
+def make_multifile_project(tmp_path: Path) -> ArxivProject:
+    project = tmp_path / "project"
+    sections = project / "sections"
+    sections.mkdir(parents=True)
+    main = project / "main.tex"
+    main.write_text(
+        "\\documentclass{article}\n"
+        "\\newtheorem{lemma}{Lemma}\n"
+        "\\newtheorem{theorem}{Theorem}\n"
+        "\\begin{document}\n"
+        "\\input{sections/lemma}\n"
+        "\\input{sections/theorem}\n"
+        "\\end{document}\n",
+        encoding="utf-8",
+    )
+    (sections / "lemma.tex").write_text(
+        "\\begin{lemma}Base.\\label{lem:base}\\end{lemma}",
+        encoding="utf-8",
+    )
+    (sections / "theorem.tex").write_text(
+        "\\begin{theorem}By \\ref{lem:base}."
+        "\\label{thm:result}\\end{theorem}",
+        encoding="utf-8",
+    )
+    return ArxivProject("2401.12345", project, main, False)
+
+
+def test_load_arxiv_paper_activates_downloaded_multifile_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    project = make_multifile_project(tmp_path)
+    monkeypatch.setattr(server, "prepare_arxiv_project", lambda *args, **kwargs: project)
+
+    result = server.load_arxiv_paper("arXiv:2401.12345")
+
+    assert result == {
+        "arxiv_id": "2401.12345",
+        "path": str(project.main_file),
+        "cached": False,
+        "nodes": 2,
+        "kinds": {"lemma": 1, "theorem": 1},
+    }
+    assert [node["id"] for node in server.list_theorems()] == [
+        "lem:base",
+        "thm:result",
+    ]
+    assert [node["id"] for node in server.get_dependencies("thm:result")] == [
+        "lem:base"
+    ]
+
+
+def test_load_arxiv_paper_passes_options_to_preparation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    project = make_multifile_project(tmp_path)
+    received: dict[str, object] = {}
+
+    def prepare(arxiv_id: str, main_file: str | None, refresh: bool):
+        received.update(
+            arxiv_id=arxiv_id,
+            main_file=main_file,
+            refresh=refresh,
+        )
+        return ArxivProject(
+            project.arxiv_id,
+            project.project_dir,
+            project.main_file,
+            True,
+        )
+
+    monkeypatch.setattr(server, "prepare_arxiv_project", prepare)
+
+    result = server.load_arxiv_paper(
+        "2401.12345",
+        main_file="main.tex",
+        refresh=True,
+    )
+
+    assert received == {
+        "arxiv_id": "2401.12345",
+        "main_file": "main.tex",
+        "refresh": True,
+    }
+    assert result["cached"] is True
+
+
+def test_arxiv_domain_error_becomes_tool_error(monkeypatch: pytest.MonkeyPatch):
+    def fail(*args, **kwargs):
+        raise ArxivDownloadError("download unavailable")
+
+    monkeypatch.setattr(server, "prepare_arxiv_project", fail)
+
+    with pytest.raises(ToolError, match="download unavailable"):
+        server.load_arxiv_paper("2401.12345")
+
+
+@pytest.mark.parametrize("failure", [OSError("cannot read"), ValueError("bad include")])
+def test_arxiv_loader_error_becomes_tool_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
+):
+    project = make_multifile_project(tmp_path)
+    monkeypatch.setattr(server, "prepare_arxiv_project", lambda *args, **kwargs: project)
+
+    def fail(path: Path):
+        raise failure
+
+    monkeypatch.setattr(server, "load_latex_project", fail)
+
+    with pytest.raises(ToolError, match=str(failure)):
+        server.load_arxiv_paper("2401.12345")
+
+
+def test_failed_arxiv_import_preserves_active_local_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    local = tmp_path / "local.tex"
+    local.write_text(
+        "\\newtheorem{lemma}{Lemma}\n"
+        "\\begin{lemma}Local.\\label{lem:local}\\end{lemma}",
+        encoding="utf-8",
+    )
+    server.load_paper(str(local))
+
+    def fail(*args, **kwargs):
+        raise ArxivDownloadError("download unavailable")
+
+    monkeypatch.setattr(server, "prepare_arxiv_project", fail)
+
+    with pytest.raises(ToolError):
+        server.load_arxiv_paper("2401.12345")
+
+    assert [node["id"] for node in server.list_theorems()] == ["lem:local"]
+    assert server._current_path == local.resolve()
+
+
+def test_missing_graph_message_mentions_both_load_tools():
+    with pytest.raises(ToolError) as caught:
+        server.require_graph()
+
+    message = str(caught.value)
+    assert "load_paper" in message
+    assert "load_arxiv_paper" in message

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -256,6 +265,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -266,6 +288,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -431,6 +468,7 @@ name = "papergraph-mcp"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
 ]
 
@@ -440,7 +478,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mcp", extras = ["cli"], specifier = ">=2,<3" }]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2,<3" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8" }]

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
PaperGraph v0.3 adds direct arXiv source importing through the new load_arxiv_paper MCP tool.

Supports modern, versioned, and legacy arXiv IDs
Safely extracts tar, gzip, and single-file TeX sources
Automatically selects the main LaTeX file
Adds persistent caching and refresh support
Preserves the active graph when an import fails
Updates the package version to 0.3.0