### PR TITLE
Prepare PaperGraph v0.4.1 release

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -38,17 +38,17 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.4.0`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.4.1`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp --version
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp --version`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp --version`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp --version`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp --version`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp --version`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp --version`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp --version`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp --version`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.4.0"
+      placeholder: "0.4.1"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.4.0"
+          test "$version" = "papergraph-mcp 0.4.1"

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ restarting the client. You can always use the manual setup below instead.
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the GitHub release without cloning the repository:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1 papergraph-mcp --version
 ```
 
-The pinned command becomes available after the `v0.4.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.4.1` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 ## MCP Configuration
 
@@ -50,7 +50,7 @@ For an MCP client that accepts JSON-style stdio server configuration, add:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1", "papergraph-mcp"]
     }
   }
 }

--- a/docs/superpowers/plans/2026-09-03-v0.4.1-release-preparation.md
+++ b/docs/superpowers/plans/2026-09-03-v0.4.1-release-preparation.md
@@ -1,0 +1,87 @@
+# PaperGraph v0.4.1 Release Preparation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare a version-consistent and fully verified PaperGraph `v0.4.1` release candidate.
+
+**Architecture:** Keep the runtime and MCP interfaces unchanged. Treat `pyproject.toml` as the package-version authority, update every active release surface to match it, and retain historical v0.4.0 records unchanged.
+
+**Tech Stack:** Python 3.10+, uv, pytest, GitHub Actions, Markdown, YAML
+
+## Global Constraints
+
+- The package version is exactly `0.4.1`; Git references use exactly `v0.4.1`.
+- Historical v0.4.0 specs, plans, and feature descriptions remain unchanged.
+- No MCP tool signatures or runtime behavior change.
+- Do not merge the pull request or create the tag before the release-preparation commit reaches `main`.
+
+---
+
+### Task 1: Define the v0.4.1 release contract in tests
+
+**Files:**
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_onboarding.py`
+- Modify: `tests/test_repository.py`
+
+**Interfaces:**
+- Consumes: existing package metadata, CLI, repository files, and onboarding checker.
+- Produces: assertions requiring package version `0.4.1` and release pin `v0.4.1`.
+
+- [ ] **Step 1: Change exact release expectations to `0.4.1` and `v0.4.1`**
+- [ ] **Step 2: Run the targeted tests and confirm they fail on the old metadata**
+
+Run:
+
+```powershell
+uv run pytest tests/test_cli.py tests/test_onboarding.py tests/test_repository.py -q
+```
+
+Expected: failures showing `0.4.0` or `v0.4.0` where `0.4.1` or `v0.4.1` is required.
+
+### Task 2: Synchronize active release surfaces
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `README.md`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+- Modify: `scripts/check_onboarding.py`
+
+**Interfaces:**
+- Consumes: the release contract from Task 1.
+- Produces: package and onboarding artifacts consistently identifying `v0.4.1`.
+
+- [ ] **Step 1: Update active version strings and regenerate the lockfile**
+- [ ] **Step 2: Run the targeted tests and confirm they pass**
+
+Run:
+
+```powershell
+uv run pytest tests/test_cli.py tests/test_onboarding.py tests/test_repository.py -q
+```
+
+Expected: all targeted tests pass.
+
+### Task 3: Validate the release candidate
+
+**Files:**
+- Verify all modified release files.
+
+**Interfaces:**
+- Consumes: version-consistent source tree from Task 2.
+- Produces: test and package-build evidence suitable for a pull request.
+
+- [ ] **Step 1: Run locked synchronization, all tests, and the onboarding checker**
+- [ ] **Step 2: Build wheel and source distribution**
+- [ ] **Step 3: Install the wheel into an isolated smoke-test environment and verify `papergraph-mcp 0.4.1`**
+- [ ] **Step 4: Review the final diff and confirm historical v0.4.0 records remain intact**
+- [ ] **Step 5: Commit, push `release/v0.4.1`, and create a pull request into `main`**
+
+Expected: `247` or more tests pass with only the known optional skip, both
+distribution artifacts are created, and the installed wheel reports
+`papergraph-mcp 0.4.1`.

--- a/docs/superpowers/specs/2026-09-03-v0.4.1-release-preparation-design.md
+++ b/docs/superpowers/specs/2026-09-03-v0.4.1-release-preparation-design.md
@@ -1,0 +1,37 @@
+# PaperGraph v0.4.1 Release Preparation Design
+
+## Goal
+
+Publish the agent-guided onboarding work as a coherent `v0.4.1` release whose
+package metadata, runtime identity, CI smoke test, issue template, README, and
+onboarding instructions all identify the same version.
+
+## Scope
+
+This is a patch release with no new MCP tools or behavioral changes. Update the
+active release surfaces from `0.4.0`/`v0.4.0` to `0.4.1`/`v0.4.1`:
+
+- `pyproject.toml` and the PaperGraph package entry in `uv.lock`;
+- the CLI version expectation, arXiv user agent, CI wheel smoke test, and bug
+  report placeholder;
+- README installation examples and release availability copy;
+- onboarding Skill commands, client recipes, checker constants, and their tests.
+
+Historical v0.4.0 design and implementation documents remain unchanged because
+they accurately describe that release. The README sentence explaining what
+v0.4.0 introduced also remains unchanged.
+
+## Verification
+
+Tests must first demonstrate that the old release metadata fails the new
+`v0.4.1` expectations. After the update, the full test suite, onboarding checker,
+locked dependency sync, package build, wheel installation, and installed CLI
+version check must pass. The release tag itself is created only after this branch
+is merged into `main`.
+
+## Delivery
+
+Commit the release preparation on `release/v0.4.1`, push it, and open a pull
+request into `main`. Do not merge the pull request automatically. After the user
+confirms it is merged, create the GitHub Release from tag `v0.4.1` with concise
+notes centered on agent-guided setup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.4.0"
+PAPERGRAPH_VERSION = "0.4.1"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.4.0"
+    "papergraph-mcp.git@v0.4.1"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -25,7 +25,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.4.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.4.1 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.4.0\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.4.1\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.0"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.1"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.4.0\n"
+        stdout = "papergraph-mcp 0.4.1\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.4.0"
+    assert result["version"] == "papergraph-mcp 0.4.1"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.0"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.1"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -332,7 +332,7 @@ def test_readme_exposes_agent_guided_setup():
     assert ".agents/skills/setting-up-papergraph/SKILL.md" in text
 
 
-def test_all_onboarding_source_pins_match_v040():
+def test_all_onboarding_source_pins_match_v041():
     import re
 
     combined = "\n".join(
@@ -343,4 +343,4 @@ def test_all_onboarding_source_pins_match_v040():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.4.0"}
+    assert set(refs) == {"v0.4.1"}

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -21,7 +21,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.4.0"
+    assert project["version"] == "0.4.1"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -65,7 +65,7 @@ def test_lockfile_matches_project_version():
         if package["name"] == "papergraph-mcp"
     )
 
-    assert package["version"] == "0.4.0"
+    assert package["version"] == "0.4.1"
 
 
 def test_runtime_and_issue_template_release_strings_match_project_version():
@@ -120,7 +120,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.4.0" in build_steps
+    assert "papergraph-mcp 0.4.1" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -228,7 +228,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.4.0"
+        "papergraph-mcp.git@v0.4.1"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bump package, runtime, CI, issue template, lockfile, README, and onboarding Skill to `0.4.1` / `v0.4.1`.
- Preserve historical `v0.4.0` release documentation.
- No MCP API or workspace schema changes.

## Testing

- `247 passed, 1 skipped`
- Built source and wheel distributions.
- Installed the wheel independently and verified `papergraph-mcp 0.4.1`.

Merge before creating the `v0.4.1` tag and GitHub Release.