### PR TITLE
Harden v0.4.3 first-use entry flow

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -17,7 +17,7 @@ Keep these four phases short and in this order. Do not show later phases as comp
 
 Briefly explain that PaperGraph lets an MCP client analyze LaTeX papers, build a multi-paper workspace, search theorem-like content, and inspect explicit citation evidence. Give the reusable prompt in a copyable block. Translate it only under the preservation rule in its reference.
 
-If a user provides both an arXiv ID and an arXiv URL, compare their normalized identifiers before loading a paper. If they differ, ask which one to analyze; do not silently prefer either value.
+If a user provides both an arXiv ID and an arXiv URL, compare their normalized identifiers with `validate_arxiv_input` before loading a paper. If they differ, ask which one to analyze; do not silently prefer either value.
 
 ### What is missing
 
@@ -40,23 +40,23 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.4.2`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.4.3`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version
 ```
 
 The expected output is:
 
 ```text
-papergraph-mcp 0.4.2
+papergraph-mcp 0.4.3
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -17,7 +17,13 @@ Keep these four phases short and in this order. Do not show later phases as comp
 
 Briefly explain that PaperGraph lets an MCP client analyze LaTeX papers, build a multi-paper workspace, search theorem-like content, and inspect explicit citation evidence. Give the reusable prompt in a copyable block. Translate it only under the preservation rule in its reference.
 
-If a user provides both an arXiv ID and an arXiv URL, compare their normalized identifiers with `validate_arxiv_input` before loading a paper. If they differ, ask which one to analyze; do not silently prefer either value.
+Before loading arXiv papers:
+
+1. If a repository directory already exists, run `git fetch --tags origin` before trusting local `origin/main`.
+2. Verify `papergraph-mcp --version` and run `papergraph-mcp doctor` or call `get_environment_diagnostics`.
+3. If a user provides both an arXiv ID and an arXiv URL, call `validate_arxiv_input` first.
+4. Call `load_arxiv_paper` only when `validate_arxiv_input` returns `action: safe_to_load`.
+5. If validation returns `action: ask_user_to_choose`, stop and ask which one to analyze. detecting a conflict and then continuing is a failure.
 
 ### What is missing
 

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp --version`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp --version`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp --version`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp --version`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -38,7 +38,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -52,7 +52,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.agents/skills/setting-up-papergraph/references/usage-prompt.md
+++ b/.agents/skills/setting-up-papergraph/references/usage-prompt.md
@@ -7,7 +7,9 @@ Present this prompt before asking for installation permission:
 
 工作区数据库保存在临时目录，不要放进 Git 仓库。依次导入我提供的论文，然后：
 
-如果我同时给出 arXiv ID and arXiv URL，请先比较二者是否指向同一篇论文；如果不一致，先问我要分析哪一个，不要自行选择。
+开始分析前，请先调用 `get_environment_diagnostics` 或运行 `papergraph-mcp doctor`，并在回答里说明 PaperGraph 版本。
+
+如果我同时给出 arXiv ID and arXiv URL，请先调用 `validate_arxiv_input` 或 `papergraph-mcp validate-arxiv`。只有当结果是 `action: safe_to_load` 时才调用 `load_arxiv_paper`；如果结果是 `action: ask_user_to_choose`，请先问我要分析哪一篇，不要继续加载。
 
 1. 列出成功导入的论文；
 2. 搜索与“fixed point”相关的定理；

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.4.2"
+      placeholder: "0.4.3"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.4.2"
+          test "$version" = "papergraph-mcp 0.4.3"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/lotchuazzz-crypto/papergraph-mcp)](https://github.com/lotchuazzz-crypto/papergraph-mcp/releases)
 
-PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.2 hardens first-use analysis with clearer theorem-kind metadata, dependency diagnostics, and guardrails against overreading sparse graphs.
+PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.3 hardens first-use analysis with clearer theorem-kind metadata, dependency diagnostics, and guardrails against overreading sparse graphs.
 
 PaperGraph v0.4.0 introduced the persistent, cross-paper SQLite workspace: retain a small literature collection, search theorem text, follow theorem dependencies, and inspect citation evidence without asking an agent to re-read every source paper.
 
@@ -42,10 +42,10 @@ PaperGraph should not silently analyze the text ID or the link target.
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the GitHub release without cloning the repository:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version
 ```
 
-The pinned command becomes available after the `v0.4.2` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.4.3` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 ## MCP Configuration
 
@@ -56,7 +56,7 @@ For an MCP client that accepts JSON-style stdio server configuration, add:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3", "papergraph-mcp"]
     }
   }
 }
@@ -87,7 +87,7 @@ For a compact single-paper check, call `load_arxiv_paper(arxiv_id="math/0307200"
 
 ## Reading Sparse Dependency Results
 
-PaperGraph v0.4.2 dependency traversal uses `statement_explicit_latex_refs_only`:
+PaperGraph v0.4.3 dependency traversal uses `statement_explicit_latex_refs_only`:
 it follows explicit LaTeX references such as `\ref`, `\eqref`, `\autoref`,
 `\cref`, and `\Cref` inside theorem-like statements. An empty dependency result
 means PaperGraph found no resolvable theorem-label references under that rule.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/lotchuazzz-crypto/papergraph-mcp)](https://github.com/lotchuazzz-crypto/papergraph-mcp/releases)
 
-PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.3 hardens first-use analysis with clearer theorem-kind metadata, dependency diagnostics, and guardrails against overreading sparse graphs.
+PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.3 hardens first-use analysis by making agents verify the running version, validate arXiv ID/URL pairs, and report dependency boundaries before interpreting sparse graphs.
 
 PaperGraph v0.4.0 introduced the persistent, cross-paper SQLite workspace: retain a small literature collection, search theorem text, follow theorem dependencies, and inspect citation evidence without asking an agent to re-read every source paper.
 
@@ -33,9 +33,13 @@ skill. The agent should show you a reusable PaperGraph prompt, explain why `uv`
 is needed, and ask before installing software, changing client configuration, or
 restarting the client. You can always use the manual setup below instead.
 
-If a prompt contains both an arXiv ID and an arXiv URL, ask the agent to compare
-the normalized identifiers before loading. If they differ, choose one explicitly;
-PaperGraph should not silently analyze the text ID or the link target.
+If your agent clones into a directory that already exists, ask it to run
+`git fetch --tags origin` before treating the checkout as current. Existing
+clones can otherwise remain pinned to an old local `origin/main`.
+
+If a prompt contains both an arXiv ID and an arXiv URL, ask the agent to call
+`validate_arxiv_input` or `papergraph-mcp validate-arxiv` before loading. Call `load_arxiv_paper` only when the validator returns `action: safe_to_load`. If it
+returns `action: ask_user_to_choose`, ask the user to choose; detecting a conflict and then continuing is a failure.
 
 ## Quick Start
 
@@ -43,9 +47,16 @@ Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then veri
 
 ```powershell
 uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version
+papergraph-mcp doctor
 ```
 
 The pinned command becomes available after the `v0.4.3` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+
+To validate conflicting arXiv input before loading a paper, run:
+
+```powershell
+papergraph-mcp validate-arxiv --id math/0307200 --url https://arxiv.org/abs/2609.01574
+```
 
 ## MCP Configuration
 
@@ -66,7 +77,7 @@ Restart the MCP client after changing its configuration. The server uses stdio, 
 
 ## Tools
 
-The original single-paper tools remain available: `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`. Their signatures are `load_paper(path: str)`, `load_arxiv_paper(arxiv_id: str, main_file: str | None = None, refresh: bool = False)`, `list_theorems(kind: str | None = None)`, `get_theorem(theorem_id: str)`, `get_dependencies(theorem_id: str, recursive: bool = False)`, `get_dependency_diagnostics(theorem_id: str, recursive: bool = False)`, and `where_used(theorem_id: str)`.
+The original single-paper tools remain available: `get_environment_diagnostics`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`. Their signatures are `get_environment_diagnostics()`, `validate_arxiv_input(text_id: str | None = None, url: str | None = None)`, `load_paper(path: str)`, `load_arxiv_paper(arxiv_id: str, main_file: str | None = None, refresh: bool = False)`, `list_theorems(kind: str | None = None)`, `get_theorem(theorem_id: str)`, `get_dependencies(theorem_id: str, recursive: bool = False)`, `get_dependency_diagnostics(theorem_id: str, recursive: bool = False)`, and `where_used(theorem_id: str)`.
 
 Workspace tools operate on the active database. Call `open_workspace` first: `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, and `workspace_get_citations` require that active workspace. Their exact MCP signatures and return summaries are:
 

--- a/docs/superpowers/plans/2026-09-03-v0.4.3-first-use-entry-hardening.md
+++ b/docs/superpowers/plans/2026-09-03-v0.4.3-first-use-entry-hardening.md
@@ -1,0 +1,1046 @@
+# PaperGraph v0.4.3 First-Use Entry Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add release/version diagnostics and arXiv ID-vs-URL validation so first-use agents prove the executable version and intended paper before loading an arXiv source.
+
+**Architecture:** Keep runtime behavior additive. Put deterministic arXiv input validation in `src/papergraph/arxiv.py`, put environment diagnostics in a new small module, and expose both through the existing CLI/MCP entry in `src/papergraph/server.py`.
+
+**Tech Stack:** Python 3.10+, argparse, importlib.metadata, pathlib, subprocess for optional git context, MCPServer decorators, pytest, existing repository/onboarding tests.
+
+## Global Constraints
+
+- Target release is exactly `0.4.3` / `v0.4.3`.
+- Tests must not depend on live arXiv or GitHub network access.
+- Existing MCP tools keep their current signatures.
+- Existing `load_arxiv_paper(arxiv_id=...)` behavior remains unchanged for callers that already know the intended ID.
+- `papergraph-mcp --help` and `papergraph-mcp --version` remain stable.
+- `validate_arxiv_input` conflict results must use `status: "conflict"`, `action: "ask_user_to_choose"`, and `selected_id: None`.
+- Do not create tags, publish releases, delete branches, clean up worktrees, or modify `D:\August\papergraph-mcp` without explicit user approval.
+
+---
+
+## File Structure
+
+- `src/papergraph/arxiv.py`: add URL extraction and `validate_arxiv_input` alongside existing ID normalization.
+- `src/papergraph/diagnostics.py`: create a focused runtime diagnostics module so `server.py` does not accumulate environment probing logic.
+- `src/papergraph/server.py`: expose `doctor`, `validate-arxiv`, `get_environment_diagnostics`, and `validate_arxiv_input`.
+- `tests/test_arxiv.py`: cover ID/URL validation states.
+- `tests/test_cli.py`: cover JSON CLI commands.
+- `tests/test_server.py`: cover MCP tool functions.
+- `tests/test_repository.py`: update version surfaces and README expectations.
+- `tests/test_onboarding.py`: update pin/version expectations and first-use ordering expectations.
+- `README.md`: update release text, first-use flow, tool list, and safety wording.
+- `.agents/skills/setting-up-papergraph/SKILL.md`: update pin/version and require diagnostics/validation order.
+- `.agents/skills/setting-up-papergraph/references/client-configuration.md`: update pins.
+- `.agents/skills/setting-up-papergraph/references/usage-prompt.md`: update reusable prompt.
+- `scripts/check_onboarding.py`: update pin/version constants and, if useful, mention `doctor` in output text.
+- `pyproject.toml`, `uv.lock`, `src/papergraph/arxiv.py`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/workflows/ci.yml`: update release version strings.
+
+---
+
+### Task 1: Version and Release Pin Baseline
+
+**Files:**
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `scripts/check_onboarding.py`
+- Modify: `README.md`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+
+**Interfaces:**
+- Consumes: existing version strings and test helpers.
+- Produces: repository version surfaces consistently set to `0.4.3` / `v0.4.3`.
+
+- [ ] **Step 1: Update failing repository version tests**
+
+In `tests/test_repository.py`, change exact v0.4.2 expectations to v0.4.3:
+
+```python
+assert project["version"] == "0.4.3"
+assert package["version"] == "0.4.3"
+assert "papergraph-mcp 0.4.3" in build_steps
+```
+
+In `test_readme_is_a_version_pinned_launch_page_with_verified_demo`, change:
+
+```python
+pinned_source = (
+    "git+https://github.com/lotchuazzz-crypto/"
+    "papergraph-mcp.git@v0.4.3"
+)
+assert "PaperGraph v0.4.3" in readme
+```
+
+In `test_onboarding_uses_v042_release_pin_and_mentions_id_url_conflicts`, rename the test and update assertions:
+
+```python
+def test_onboarding_uses_v043_release_pin_and_mentions_id_url_conflicts():
+    skill = (
+        ROOT / ".agents/skills/setting-up-papergraph/SKILL.md"
+    ).read_text(encoding="utf-8")
+    prompt = (
+        ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
+    ).read_text(encoding="utf-8")
+
+    assert "papergraph-mcp.git@v0.4.3" in skill
+    assert "papergraph-mcp 0.4.3" in skill
+    assert "validate_arxiv_input" in skill
+    assert "ask which one to analyze" in skill
+    assert "arXiv ID and arXiv URL" in prompt
+```
+
+In `tests/test_onboarding.py`, update:
+
+```python
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3"
+```
+
+and every expected stdout/version payload:
+
+```python
+stdout = "papergraph-mcp 0.4.3\n"
+launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.3"}
+```
+
+Rename `test_all_onboarding_source_pins_match_v042` to:
+
+```python
+def test_all_onboarding_source_pins_match_v043():
+    ...
+    assert set(refs) == {"v0.4.3"}
+```
+
+- [ ] **Step 2: Run version tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: FAIL because source files still contain `0.4.2` / `v0.4.2`.
+
+- [ ] **Step 3: Update version surfaces**
+
+Apply these source changes:
+
+```toml
+# pyproject.toml
+version = "0.4.3"
+```
+
+```python
+# src/papergraph/arxiv.py
+_USER_AGENT = "PaperGraph/0.4.3 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+```
+
+Update `uv.lock` local package metadata to `0.4.3` by running:
+
+```powershell
+.\.venv\Scripts\python.exe -m pip install --no-deps -e .
+```
+
+If `uv` is available and preferred, run:
+
+```powershell
+uv lock
+```
+
+Update `.github/ISSUE_TEMPLATE/bug_report.yml` version placeholder:
+
+```yaml
+placeholder: "0.4.3"
+```
+
+Update `.github/workflows/ci.yml` wheel smoke expectation:
+
+```bash
+papergraph-mcp 0.4.3
+```
+
+Update `scripts/check_onboarding.py` constants:
+
+```python
+PAPERGRAPH_VERSION = "0.4.3"
+PAPERGRAPH_SOURCE = (
+    "git+https://github.com/lotchuazzz-crypto/"
+    "papergraph-mcp.git@v0.4.3"
+)
+```
+
+Update README and onboarding release pins from `v0.4.2` to `v0.4.3`, and version prose from `0.4.2` to `0.4.3`.
+
+- [ ] **Step 4: Run version tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: PASS for all selected tests.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add pyproject.toml uv.lock src/papergraph/arxiv.py .github/ISSUE_TEMPLATE/bug_report.yml .github/workflows/ci.yml scripts/check_onboarding.py README.md .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/client-configuration.md tests/test_repository.py tests/test_onboarding.py
+git commit -m "Prepare v0.4.3 version baseline"
+```
+
+---
+
+### Task 2: arXiv Input Validation Core
+
+**Files:**
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `tests/test_arxiv.py`
+
+**Interfaces:**
+- Consumes: `normalize_arxiv_id(value: str) -> str` and `InvalidArxivIdError`.
+- Produces:
+  - `extract_arxiv_id_from_url(url: str) -> str`
+  - `validate_arxiv_input(text_id: str | None = None, url: str | None = None) -> dict`
+
+- [ ] **Step 1: Add failing tests for URL extraction and validation**
+
+Append to `tests/test_arxiv.py`:
+
+```python
+from papergraph.arxiv import extract_arxiv_id_from_url, validate_arxiv_input
+```
+
+Add:
+
+```python
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://arxiv.org/abs/2609.01574", "2609.01574"),
+        ("https://arxiv.org/abs/2609.01574v2", "2609.01574v2"),
+        ("https://arxiv.org/pdf/math/0307200", "math/0307200"),
+        ("https://export.arxiv.org/abs/hep-th/9901001v3", "hep-th/9901001v3"),
+    ],
+)
+def test_extracts_arxiv_id_from_supported_urls(url: str, expected: str):
+    assert extract_arxiv_id_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "https://example.com/abs/2609.01574",
+        "https://arxiv.org/",
+        "https://arxiv.org/abs/not-an-id",
+        "not a url",
+    ],
+)
+def test_rejects_unsupported_arxiv_urls(url: str):
+    with pytest.raises(InvalidArxivIdError):
+        extract_arxiv_id_from_url(url)
+
+
+def test_validate_arxiv_input_allows_matching_text_and_url():
+    result = validate_arxiv_input(
+        text_id="arXiv:2609.01574",
+        url="https://arxiv.org/abs/2609.01574",
+    )
+
+    assert result == {
+        "text_id": "arXiv:2609.01574",
+        "url": "https://arxiv.org/abs/2609.01574",
+        "normalized_text_id": "2609.01574",
+        "normalized_url_id": "2609.01574",
+        "status": "match",
+        "action": "safe_to_load",
+        "selected_id": "2609.01574",
+        "message": "The text arXiv ID and arXiv URL identify the same paper. It is safe to load 2609.01574.",
+        "errors": [],
+    }
+
+
+def test_validate_arxiv_input_stops_on_conflict():
+    result = validate_arxiv_input(
+        text_id="math/0307200",
+        url="https://arxiv.org/abs/2609.01574",
+    )
+
+    assert result["normalized_text_id"] == "math/0307200"
+    assert result["normalized_url_id"] == "2609.01574"
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert "ask the user" in result["message"].lower()
+    assert result["errors"] == []
+
+
+@pytest.mark.parametrize(
+    ("text_id", "url", "selected"),
+    [
+        ("math/0307200", None, "math/0307200"),
+        (None, "https://arxiv.org/abs/2609.01574", "2609.01574"),
+    ],
+)
+def test_validate_arxiv_input_accepts_single_input(text_id, url, selected):
+    result = validate_arxiv_input(text_id=text_id, url=url)
+
+    assert result["status"] == "single_input"
+    assert result["action"] == "safe_to_load"
+    assert result["selected_id"] == selected
+    assert result["errors"] == []
+
+
+def test_validate_arxiv_input_reports_invalid_inputs_without_selection():
+    result = validate_arxiv_input(
+        text_id="not-an-id",
+        url="https://example.com/abs/2609.01574",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_text_id"] is None
+    assert result["normalized_url_id"] is None
+    assert len(result["errors"]) == 2
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_arxiv.py -q -p no:cacheprovider
+```
+
+Expected: FAIL importing `extract_arxiv_id_from_url` or `validate_arxiv_input`.
+
+- [ ] **Step 3: Implement URL extraction and validator**
+
+In `src/papergraph/arxiv.py`, add imports:
+
+```python
+from urllib.parse import urlparse
+```
+
+Add near the ID regex constants:
+
+```python
+_ARXIV_URL_HOSTS = {"arxiv.org", "www.arxiv.org", "export.arxiv.org"}
+_ARXIV_URL_PREFIXES = {"/abs/", "/pdf/"}
+```
+
+Add after `normalize_arxiv_id`:
+
+```python
+def extract_arxiv_id_from_url(url: str) -> str:
+    """Extract and validate an arXiv identifier from a supported arXiv URL."""
+
+    if not isinstance(url, str):
+        raise InvalidArxivIdError("arXiv URL must be text")
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"} or parsed.netloc.lower() not in _ARXIV_URL_HOSTS:
+        raise InvalidArxivIdError(f"Unsupported arXiv URL: {url!r}")
+
+    path = parsed.path.rstrip("/")
+    for prefix in _ARXIV_URL_PREFIXES:
+        if path.startswith(prefix):
+            candidate = path[len(prefix):]
+            if prefix == "/pdf/" and candidate.endswith(".pdf"):
+                candidate = candidate[:-4]
+            return normalize_arxiv_id(candidate)
+
+    raise InvalidArxivIdError(f"Unsupported arXiv URL: {url!r}")
+
+
+def validate_arxiv_input(
+    text_id: str | None = None,
+    url: str | None = None,
+) -> dict:
+    """Normalize text and URL arXiv inputs and return the safe next action."""
+
+    normalized_text_id: str | None = None
+    normalized_url_id: str | None = None
+    errors: list[str] = []
+
+    if text_id is not None:
+        try:
+            normalized_text_id = normalize_arxiv_id(text_id)
+        except InvalidArxivIdError as exc:
+            errors.append(str(exc))
+
+    if url is not None:
+        try:
+            normalized_url_id = extract_arxiv_id_from_url(url)
+        except InvalidArxivIdError as exc:
+            errors.append(str(exc))
+
+    if errors or (normalized_text_id is None and normalized_url_id is None):
+        if not errors:
+            errors.append("Provide an arXiv text ID, an arXiv URL, or both.")
+        return {
+            "text_id": text_id,
+            "url": url,
+            "normalized_text_id": normalized_text_id,
+            "normalized_url_id": normalized_url_id,
+            "status": "invalid",
+            "action": "ask_user_to_choose",
+            "selected_id": None,
+            "message": "The arXiv input is invalid. Ask the user for one supported arXiv ID or URL before loading a paper.",
+            "errors": errors,
+        }
+
+    if normalized_text_id is not None and normalized_url_id is not None:
+        if normalized_text_id != normalized_url_id:
+            return {
+                "text_id": text_id,
+                "url": url,
+                "normalized_text_id": normalized_text_id,
+                "normalized_url_id": normalized_url_id,
+                "status": "conflict",
+                "action": "ask_user_to_choose",
+                "selected_id": None,
+                "message": (
+                    "The text arXiv ID and arXiv URL identify different papers. "
+                    "Ask the user which one to analyze before calling load_arxiv_paper."
+                ),
+                "errors": [],
+            }
+        return {
+            "text_id": text_id,
+            "url": url,
+            "normalized_text_id": normalized_text_id,
+            "normalized_url_id": normalized_url_id,
+            "status": "match",
+            "action": "safe_to_load",
+            "selected_id": normalized_text_id,
+            "message": (
+                "The text arXiv ID and arXiv URL identify the same paper. "
+                f"It is safe to load {normalized_text_id}."
+            ),
+            "errors": [],
+        }
+
+    selected_id = normalized_text_id or normalized_url_id
+    return {
+        "text_id": text_id,
+        "url": url,
+        "normalized_text_id": normalized_text_id,
+        "normalized_url_id": normalized_url_id,
+        "status": "single_input",
+        "action": "safe_to_load",
+        "selected_id": selected_id,
+        "message": f"One arXiv input was provided. It is safe to load {selected_id}.",
+        "errors": [],
+    }
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_arxiv.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/arxiv.py tests/test_arxiv.py
+git commit -m "Add arXiv input validation"
+```
+
+---
+
+### Task 3: Environment Diagnostics Core
+
+**Files:**
+- Create: `src/papergraph/diagnostics.py`
+- Create: `tests/test_diagnostics.py`
+
+**Interfaces:**
+- Consumes: `papergraph.models.DEPENDENCY_EXTRACTION_BASIS`.
+- Produces:
+  - `environment_diagnostics() -> dict`
+  - `PACKAGE_NAME = "papergraph-mcp"`
+  - `REPOSITORY_SOURCE = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git"`
+
+- [ ] **Step 1: Add failing diagnostics tests**
+
+Create `tests/test_diagnostics.py`:
+
+```python
+from papergraph.diagnostics import environment_diagnostics
+
+
+def test_environment_diagnostics_reports_version_and_release_source():
+    result = environment_diagnostics()
+
+    assert result["package_name"] == "papergraph-mcp"
+    assert result["version"] == "0.4.3"
+    assert result["release_tag"] == "v0.4.3"
+    assert (
+        result["recommended_source"]
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3"
+    )
+    assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
+    assert isinstance(result["warnings"], list)
+
+
+def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
+    import papergraph.diagnostics as diagnostics
+
+    def fail(*_args, **_kwargs):
+        raise OSError("git unavailable")
+
+    monkeypatch.setattr(diagnostics.subprocess, "run", fail)
+
+    result = environment_diagnostics()
+
+    assert result["version"] == "0.4.3"
+    assert result["git"] is None
+    assert any("Git context unavailable" in warning for warning in result["warnings"])
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_diagnostics.py -q -p no:cacheprovider
+```
+
+Expected: FAIL because `papergraph.diagnostics` does not exist.
+
+- [ ] **Step 3: Implement diagnostics module**
+
+Create `src/papergraph/diagnostics.py`:
+
+```python
+"""Runtime diagnostics for first-use PaperGraph setup."""
+
+from __future__ import annotations
+
+import subprocess
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+
+from papergraph.models import DEPENDENCY_EXTRACTION_BASIS
+
+
+PACKAGE_NAME = "papergraph-mcp"
+REPOSITORY_SOURCE = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git"
+
+
+def _git_output(args: list[str], cwd: Path) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _git_context(cwd: Path) -> dict | None:
+    try:
+        top_level = _git_output(["rev-parse", "--show-toplevel"], cwd)
+        commit = _git_output(["rev-parse", "--short=12", "HEAD"], cwd)
+        branch = _git_output(["branch", "--show-current"], cwd)
+        return {
+            "top_level": top_level,
+            "commit": commit,
+            "branch": branch or None,
+        }
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def environment_diagnostics(cwd: Path | None = None) -> dict:
+    """Return deterministic setup information for agents and users."""
+
+    version = distribution_version(PACKAGE_NAME)
+    release_tag = f"v{version}"
+    git = _git_context((cwd or Path.cwd()).resolve())
+    warnings: list[str] = []
+
+    if git is None:
+        warnings.append("Git context unavailable; use the release-pinned uvx source for reproducible first use.")
+
+    return {
+        "package_name": PACKAGE_NAME,
+        "version": version,
+        "release_tag": release_tag,
+        "recommended_source": f"{REPOSITORY_SOURCE}@{release_tag}",
+        "dependency_extraction_basis": DEPENDENCY_EXTRACTION_BASIS,
+        "git": git,
+        "warnings": warnings,
+    }
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_diagnostics.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/diagnostics.py tests/test_diagnostics.py
+git commit -m "Add environment diagnostics"
+```
+
+---
+
+### Task 4: CLI and MCP Exposure
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_server.py`
+
+**Interfaces:**
+- Consumes:
+  - `papergraph.arxiv.validate_arxiv_input(text_id: str | None, url: str | None) -> dict`
+  - `papergraph.diagnostics.environment_diagnostics() -> dict`
+- Produces:
+  - CLI `papergraph-mcp doctor`
+  - CLI `papergraph-mcp validate-arxiv --id ... --url ...`
+  - MCP tool `get_environment_diagnostics() -> dict`
+  - MCP tool `validate_arxiv_input(text_id: str | None = None, url: str | None = None) -> dict`
+
+- [ ] **Step 1: Add failing CLI tests**
+
+In `tests/test_cli.py`, add imports:
+
+```python
+import json
+```
+
+Add:
+
+```python
+def test_doctor_prints_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+    monkeypatch.setattr(
+        server,
+        "environment_diagnostics",
+        lambda: {
+            "package_name": "papergraph-mcp",
+            "version": "0.4.3",
+            "release_tag": "v0.4.3",
+            "recommended_source": "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3",
+            "dependency_extraction_basis": "statement_explicit_latex_refs_only",
+            "git": None,
+            "warnings": [],
+        },
+    )
+
+    server.main(["doctor"])
+
+    assert json.loads(capsys.readouterr().out)["version"] == "0.4.3"
+
+
+def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+
+    server.main(
+        [
+            "validate-arxiv",
+            "--id",
+            "math/0307200",
+            "--url",
+            "https://arxiv.org/abs/2609.01574",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "conflict"
+    assert payload["action"] == "ask_user_to_choose"
+    assert payload["selected_id"] is None
+```
+
+- [ ] **Step 2: Add failing MCP tests**
+
+In `tests/test_server.py`, add:
+
+```python
+def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "environment_diagnostics",
+        lambda: {
+            "package_name": "papergraph-mcp",
+            "version": "0.4.3",
+            "release_tag": "v0.4.3",
+            "recommended_source": "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3",
+            "dependency_extraction_basis": "statement_explicit_latex_refs_only",
+            "git": None,
+            "warnings": [],
+        },
+    )
+
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.4.3"
+
+
+def test_validate_arxiv_input_tool_reports_conflict():
+    result = server.validate_arxiv_input(
+        text_id="math/0307200",
+        url="https://arxiv.org/abs/2609.01574",
+    )
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_cli.py tests/test_server.py -q -p no:cacheprovider
+```
+
+Expected: FAIL because CLI subcommands and MCP tool wrappers are not implemented.
+
+- [ ] **Step 4: Implement CLI/MCP wrappers**
+
+In `src/papergraph/server.py`, add imports:
+
+```python
+import json
+
+from papergraph.arxiv import (
+    ArxivImportError,
+    prepare_arxiv_project,
+    validate_arxiv_input as validate_arxiv_input_result,
+)
+from papergraph.diagnostics import environment_diagnostics
+```
+
+Keep the existing `ArxivImportError` and `prepare_arxiv_project` import behavior while adding `validate_arxiv_input_result`.
+
+Add MCP tools near the other global tools:
+
+```python
+@mcp.tool()
+def get_environment_diagnostics() -> dict:
+    """Return PaperGraph version and reproducible launch diagnostics."""
+
+    return environment_diagnostics()
+
+
+@mcp.tool()
+def validate_arxiv_input(
+    text_id: str | None = None,
+    url: str | None = None,
+) -> dict:
+    """Normalize arXiv ID and URL inputs and return the safe next action."""
+
+    return validate_arxiv_input_result(text_id=text_id, url=url)
+```
+
+Replace `main` with subcommand-aware parsing:
+
+```python
+def _print_json(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="papergraph-mcp",
+        description="Expose LaTeX theorem dependency graphs through MCP.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {distribution_version('papergraph-mcp')}",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser(
+        "doctor",
+        help="Print PaperGraph environment diagnostics as JSON.",
+    )
+    validate_parser = subparsers.add_parser(
+        "validate-arxiv",
+        help="Validate arXiv ID and URL inputs before loading a paper.",
+    )
+    validate_parser.add_argument("--id", dest="text_id")
+    validate_parser.add_argument("--url")
+
+    args = parser.parse_args(argv)
+    if args.command == "doctor":
+        _print_json(environment_diagnostics())
+        return
+    if args.command == "validate-arxiv":
+        _print_json(
+            validate_arxiv_input_result(
+                text_id=args.text_id,
+                url=args.url,
+            )
+        )
+        return
+    mcp.run()
+```
+
+- [ ] **Step 5: Run focused tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_cli.py tests/test_server.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_cli.py tests/test_server.py
+git commit -m "Expose first-use diagnostics tools"
+```
+
+---
+
+### Task 5: README and Onboarding First-Use Flow
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/usage-prompt.md`
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+
+**Interfaces:**
+- Consumes:
+  - CLI `papergraph-mcp doctor`
+  - CLI `papergraph-mcp validate-arxiv`
+  - MCP `get_environment_diagnostics()`
+  - MCP `validate_arxiv_input(...)`
+- Produces: public first-use instructions that refresh stale clones, verify version, validate arXiv conflicts, and stop on conflict.
+
+- [ ] **Step 1: Add failing README/onboarding assertions**
+
+In `tests/test_repository.py`, extend `test_readme_is_a_version_pinned_launch_page_with_verified_demo`:
+
+```python
+assert "papergraph-mcp doctor" in readme
+assert "validate-arxiv" in readme
+assert "`get_environment_diagnostics`" in readme
+assert "`validate_arxiv_input`" in readme
+assert "git fetch --tags origin" in readme
+assert "Call `load_arxiv_paper` only when" in readme
+assert "detecting a conflict and then continuing is a failure" in readme
+```
+
+In `tests/test_onboarding.py`, add:
+
+```python
+def test_onboarding_requires_refresh_diagnostics_and_conflict_stop():
+    skill = read(SKILL / "SKILL.md")
+    prompt = read(SKILL / "references" / "usage-prompt.md")
+    client_reference = read(SKILL / "references" / "client-configuration.md")
+
+    assert "git fetch --tags origin" in skill
+    assert "papergraph-mcp doctor" in skill
+    assert "validate_arxiv_input" in skill
+    assert "Call `load_arxiv_paper` only when" in skill
+    assert "detecting a conflict and then continuing is a failure" in skill
+    assert "get_environment_diagnostics" in prompt
+    assert "validate_arxiv_input" in prompt
+    assert "ask_user_to_choose" in prompt
+    assert "papergraph-mcp doctor" in client_reference
+```
+
+- [ ] **Step 2: Run documentation tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: FAIL until README and onboarding artifacts mention the new flow.
+
+- [ ] **Step 3: Update README**
+
+In `README.md`, update the opening release sentence:
+
+```markdown
+PaperGraph v0.4.3 hardens first-use analysis by making agents verify the running version, validate arXiv ID/URL pairs, and report dependency boundaries before interpreting sparse graphs.
+```
+
+In the first-use section, include this content in prose:
+
+- If your agent clones into a directory that already exists, ask it to run `git fetch --tags origin` before treating the checkout as current. Existing clones can otherwise remain pinned to an old local `origin/main`.
+- Verify the pinned launch with `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version`.
+- Run `papergraph-mcp doctor` before claiming the running PaperGraph version.
+- If a prompt contains both an arXiv ID and an arXiv URL, validate them before loading with `papergraph-mcp validate-arxiv --id math/0307200 --url https://arxiv.org/abs/2609.01574`.
+- Call `load_arxiv_paper` only when the validator returns `action: safe_to_load`. If it returns `action: ask_user_to_choose`, ask the user to choose; detecting a conflict and then continuing is a failure.
+
+Add the new MCP tools to the tool list:
+
+```markdown
+The original single-paper tools remain available: `get_environment_diagnostics`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, ...
+```
+
+- [ ] **Step 4: Update onboarding skill and references**
+
+In `.agents/skills/setting-up-papergraph/SKILL.md`, add a first-use ordering rule:
+
+```markdown
+Before loading arXiv papers:
+
+1. If a repository directory already exists, run `git fetch --tags origin` before trusting local `origin/main`.
+2. Verify `papergraph-mcp --version` and run `papergraph-mcp doctor` or call `get_environment_diagnostics`.
+3. If the prompt includes both an arXiv ID and an arXiv URL, call `validate_arxiv_input` first.
+4. Call `load_arxiv_paper` only when `validate_arxiv_input` returns `action: safe_to_load`.
+5. If validation returns `action: ask_user_to_choose`, stop and ask the user which paper to analyze. Detecting a conflict and then continuing is a failure.
+```
+
+In `.agents/skills/setting-up-papergraph/references/client-configuration.md`, add `papergraph-mcp doctor` to launch validation instructions after `--version`.
+
+In `.agents/skills/setting-up-papergraph/references/usage-prompt.md`, add:
+
+```markdown
+如果我同时给出 arXiv ID and arXiv URL，请先调用 `validate_arxiv_input` 或 `papergraph-mcp validate-arxiv`。只有当结果是 `action: safe_to_load` 时才调用 `load_arxiv_paper`；如果结果是 `action: ask_user_to_choose`，请先问我要分析哪一篇，不要继续加载。
+```
+
+- [ ] **Step 5: Run documentation tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add README.md .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/client-configuration.md .agents/skills/setting-up-papergraph/references/usage-prompt.md tests/test_repository.py tests/test_onboarding.py
+git commit -m "Document first-use validation flow"
+```
+
+---
+
+### Task 6: Full Verification and Review Prep
+
+**Files:**
+- Verify: whole repository
+
+**Interfaces:**
+- Consumes: all previous tasks.
+- Produces: verified branch ready for PR or merge decision.
+
+- [ ] **Step 1: Run full test suite**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+```
+
+Expected: PASS, with the known skipped test count if unchanged.
+
+- [ ] **Step 2: Verify CLI behavior manually**
+
+Run:
+
+```powershell
+.\.venv\Scripts\papergraph-mcp.exe --version
+.\.venv\Scripts\papergraph-mcp.exe doctor
+.\.venv\Scripts\papergraph-mcp.exe validate-arxiv --id math/0307200 --url https://arxiv.org/abs/2609.01574
+```
+
+Expected:
+
+```text
+papergraph-mcp 0.4.3
+```
+
+`doctor` prints JSON containing `"version": "0.4.3"` and `"release_tag": "v0.4.3"`.
+
+`validate-arxiv` prints JSON containing:
+
+```json
+{
+  "status": "conflict",
+  "action": "ask_user_to_choose",
+  "selected_id": null
+}
+```
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```powershell
+git status --short
+git diff --stat origin/main...HEAD
+git diff --check
+```
+
+Expected: only v0.4.3 hardening files changed; no whitespace errors.
+
+- [ ] **Step 4: Commit any verification-only documentation corrections**
+
+If verification reveals a documentation typo or test expectation mismatch, fix only that narrow issue and commit:
+
+```powershell
+git add <changed-files>
+git commit -m "Polish v0.4.3 first-use hardening"
+```
+
+Expected: no commit if there are no corrections.
+
+- [ ] **Step 5: Handoff for review**
+
+Prepare a concise summary:
+
+```markdown
+Summary:
+- Added arXiv ID/URL validation with conflict-stop behavior.
+- Added environment diagnostics through CLI and MCP.
+- Updated v0.4.3 pins and first-use onboarding flow.
+
+Testing:
+- `.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider`
+- `.\.venv\Scripts\papergraph-mcp.exe --version`
+- `.\.venv\Scripts\papergraph-mcp.exe doctor`
+- `.\.venv\Scripts\papergraph-mcp.exe validate-arxiv --id math/0307200 --url https://arxiv.org/abs/2609.01574`
+```
+
+Do not tag or publish `v0.4.3` until the user explicitly approves release.
+
+---
+
+## Self-Review
+
+- Spec coverage: Task 1 covers the `0.4.3` / `v0.4.3` release baseline; Task 2 covers arXiv URL extraction and match/conflict/single/invalid validation; Task 3 covers deterministic environment diagnostics; Task 4 exposes CLI and MCP entry points; Task 5 updates README/onboarding first-use order and conflict-stop rules; Task 6 verifies tests, CLI behavior, and review readiness.
+- Placeholder scan: no TBD/TODO/fill-later placeholders remain. Each implementation task includes explicit files, signatures, tests, commands, expected results, and commit commands.
+- Type consistency: `validate_arxiv_input(text_id: str | None = None, url: str | None = None) -> dict`, `extract_arxiv_id_from_url(url: str) -> str`, and `environment_diagnostics() -> dict` are introduced before use by CLI, MCP, README, and onboarding tests.

--- a/docs/superpowers/specs/2026-09-03-v0.4.3-first-use-entry-hardening-design.md
+++ b/docs/superpowers/specs/2026-09-03-v0.4.3-first-use-entry-hardening-design.md
@@ -1,0 +1,211 @@
+# PaperGraph v0.4.3 First-Use Entry Hardening Design
+
+## Goal
+
+Make the first PaperGraph run prove two facts before a user or agent analyzes a
+paper:
+
+1. The PaperGraph executable is the intended current release, not a stale local
+   clone or old MCP configuration.
+2. Ambiguous arXiv input has been normalized and checked, so an agent does not
+   silently load the wrong paper when a text ID and a Markdown link disagree.
+
+This release is a narrow hardening release. It strengthens the entry path added
+in v0.4.2 without adding proof parsing, theorem ranking, semantic dependency
+inference, or cross-paper auto-import.
+
+## Problem
+
+A simulated first-time user asked an agent to clone
+`https://github.com/lotchuazzz-crypto/papergraph-mcp` and load arXiv
+`math/0307200`, while the Markdown link pointed to
+`https://arxiv.org/abs/2609.01574`.
+
+The agent reused an existing `D:\August\papergraph-mcp` clone whose local
+`origin/main` still pointed at `549caa7` / `v0.4.1`. That bypassed the v0.4.2
+README and onboarding changes. The agent noticed the ID/URL mismatch, but still
+continued with `math/0307200`. The answer was more careful than v0.4.1, but it
+still violated the desired first-use behavior: conflict should stop loading.
+
+## Success Criteria
+
+- A release-pinned first-use command can report `papergraph-mcp 0.4.3`.
+- A diagnostic command or MCP tool reports enough environment context for an
+  agent to say which PaperGraph release it is using.
+- Repository setup instructions tell agents to refresh an existing clone with
+  `git fetch --tags origin` before treating it as current.
+- PaperGraph exposes a dedicated arXiv input validator.
+- If the validator receives conflicting normalized IDs, its result says the
+  action is to ask the user to choose, not to load either paper.
+- README and onboarding instructions require `validate_arxiv_input` before
+  `load_arxiv_paper` when both a text arXiv ID and an arXiv URL appear in the
+  user prompt.
+- Tests cover version surfaces, diagnostic shape, arXiv match/conflict/invalid
+  cases, server tool exposure, and onboarding text.
+
+## Architecture
+
+v0.4.3 adds two small entry-layer capabilities:
+
+1. Environment diagnostics, available from both CLI and MCP.
+2. arXiv input normalization and conflict detection, available from both CLI
+   and MCP.
+
+Both capabilities are deterministic and network-free. They should not download
+papers, contact GitHub, inspect private MCP client configuration, or infer a
+main theorem. Their purpose is to make the safe next action explicit.
+
+## Environment Diagnostics
+
+Add a runtime function that returns a dictionary with at least:
+
+- `package_name`: `papergraph-mcp`.
+- `version`: installed distribution version.
+- `release_tag`: `v<version>`.
+- `recommended_source`: the release-pinned Git source for `uvx --from`.
+- `dependency_extraction_basis`: the existing dependency basis string.
+- `warnings`: a list of conservative warnings.
+
+The CLI command is:
+
+```powershell
+papergraph-mcp doctor
+```
+
+It prints JSON and exits successfully. The MCP tool is:
+
+```text
+get_environment_diagnostics() -> dict
+```
+
+The diagnostic should avoid live GitHub checks. If it can cheaply detect that it
+is running from inside a Git checkout, it may report local git context such as
+branch and commit. It must not fail when Git is unavailable. The important
+first-use guarantee is that an agent can quote the installed package version and
+the release-pinned source that should be used for reproducible launch.
+
+## arXiv Input Validation
+
+Add a parser/validator that accepts optional text ID and optional URL:
+
+```text
+validate_arxiv_input(text_id: str | None = None, url: str | None = None) -> dict
+```
+
+The CLI command is:
+
+```powershell
+papergraph-mcp validate-arxiv --id math/0307200 --url https://arxiv.org/abs/2609.01574
+```
+
+The result contains:
+
+- `text_id`: original text ID or `null`.
+- `url`: original URL or `null`.
+- `normalized_text_id`: normalized text ID or `null`.
+- `normalized_url_id`: normalized URL ID or `null`.
+- `status`: one of `match`, `conflict`, `single_input`, or `invalid`.
+- `action`: one of `safe_to_load` or `ask_user_to_choose`.
+- `selected_id`: the normalized ID only when safe to load.
+- `message`: a concise agent-facing explanation.
+- `errors`: validation errors for invalid inputs.
+
+Conflict behavior is the hard rule:
+
+```json
+{
+  "status": "conflict",
+  "action": "ask_user_to_choose",
+  "selected_id": null
+}
+```
+
+The validator should support modern arXiv IDs such as `2609.01574`, optional
+versions such as `2609.01574v2`, legacy IDs such as `math/0307200`, and arXiv
+abstract URLs such as `https://arxiv.org/abs/2609.01574`. It may reject
+non-arXiv URLs in v0.4.3.
+
+The validator does not decide which input is more authoritative. When the IDs
+conflict, the only correct next step is to ask the user.
+
+## README and Onboarding Flow
+
+The public first-use instructions should be rewritten around this sequence:
+
+1. If cloning into a directory that already exists, first run
+   `git fetch --tags origin` and verify the intended release or branch.
+2. Prefer the release-pinned launch command:
+
+   ```powershell
+   uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version
+   ```
+
+3. Run `papergraph-mcp doctor` or call `get_environment_diagnostics`.
+4. If the user's prompt contains both an arXiv ID and an arXiv URL, call
+   `validate_arxiv_input` before any paper-loading tool.
+5. Call `load_arxiv_paper` only when the validator returns
+   `action: safe_to_load`.
+6. In the final answer, report the PaperGraph version, the arXiv validation
+   result, and dependency diagnostics before interpreting empty dependencies.
+
+The repository-local Codex skill and reusable prompt should use the same order.
+They should explicitly state that detecting a conflict and then continuing is a
+failure.
+
+## Compatibility
+
+- Existing MCP tools keep their current signatures.
+- Existing `load_arxiv_paper(arxiv_id=...)` behavior remains unchanged for
+  callers that already know the intended ID.
+- `papergraph-mcp --help` and `papergraph-mcp --version` remain stable.
+- The new validator is additive; it does not change the arXiv download pipeline.
+
+## Testing
+
+Tests must not rely on live arXiv or GitHub network access.
+
+Add focused tests for:
+
+- `papergraph-mcp doctor` JSON shape and version value.
+- `get_environment_diagnostics` MCP tool exposure.
+- modern ID normalization.
+- legacy ID normalization.
+- arXiv URL extraction.
+- matching text ID and URL.
+- conflicting text ID and URL.
+- invalid URL or invalid ID.
+- CLI `validate-arxiv` JSON output.
+- README and onboarding pin `v0.4.3`.
+- README and onboarding require clone refresh before reusing an existing clone.
+- README and onboarding require validator-before-load and conflict-stop behavior.
+
+Full verification remains:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+```
+
+After merge and release, the external smoke test is:
+
+```powershell
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version
+```
+
+## Release Boundaries
+
+The target release is `0.4.3` / `v0.4.3`.
+
+Do not create tags, publish releases, delete branches, clean up worktrees, or
+modify the separate `D:\August\papergraph-mcp` clone without explicit user
+approval.
+
+## Future Direction
+
+Once v0.4.3 makes the entry path reliable, v0.5 can return to mathematical
+substance:
+
+- proof-aware dependency extraction;
+- main theorem candidate ranking with explicit uncertainty;
+- real-paper regression fixtures from public arXiv sources;
+- cross-paper dependency and citation workflows that preserve unresolved
+  evidence instead of guessing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.4.2"
+PAPERGRAPH_VERSION = "0.4.3"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.4.2"
+    "papergraph-mcp.git@v0.4.3"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -10,6 +10,7 @@ import tempfile
 import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
 
 import httpx
 
@@ -30,6 +31,8 @@ _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"
 )
+_ARXIV_URL_HOSTS = {"arxiv.org", "www.arxiv.org", "export.arxiv.org"}
+_ARXIV_URL_PREFIXES = {"/abs/", "/pdf/"}
 _HTTP_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=60.0, pool=10.0)
 _DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
 _ROOT_COMMAND_READ_LIMIT = 1024 * 1024
@@ -84,6 +87,115 @@ def normalize_arxiv_id(value: str) -> str:
     ):
         raise InvalidArxivIdError(f"Invalid arXiv identifier: {value!r}")
     return normalized
+
+
+def extract_arxiv_id_from_url(url: str) -> str:
+    """Extract and validate an arXiv identifier from a supported arXiv URL."""
+
+    if not isinstance(url, str):
+        raise InvalidArxivIdError("arXiv URL must be text")
+    parsed = urlparse(url.strip())
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.netloc.lower() not in _ARXIV_URL_HOSTS
+    ):
+        raise InvalidArxivIdError(f"Unsupported arXiv URL: {url!r}")
+
+    path = parsed.path.rstrip("/")
+    for prefix in _ARXIV_URL_PREFIXES:
+        if path.startswith(prefix):
+            candidate = path[len(prefix):]
+            if prefix == "/pdf/" and candidate.endswith(".pdf"):
+                candidate = candidate[:-4]
+            return normalize_arxiv_id(candidate)
+
+    raise InvalidArxivIdError(f"Unsupported arXiv URL: {url!r}")
+
+
+def validate_arxiv_input(
+    text_id: str | None = None,
+    url: str | None = None,
+) -> dict:
+    """Normalize text and URL arXiv inputs and return the safe next action."""
+
+    normalized_text_id: str | None = None
+    normalized_url_id: str | None = None
+    errors: list[str] = []
+
+    if text_id is not None:
+        try:
+            normalized_text_id = normalize_arxiv_id(text_id)
+        except InvalidArxivIdError as exc:
+            errors.append(str(exc))
+
+    if url is not None:
+        try:
+            normalized_url_id = extract_arxiv_id_from_url(url)
+        except InvalidArxivIdError as exc:
+            errors.append(str(exc))
+
+    if errors or (normalized_text_id is None and normalized_url_id is None):
+        if not errors:
+            errors.append("Provide an arXiv text ID, an arXiv URL, or both.")
+        return {
+            "text_id": text_id,
+            "url": url,
+            "normalized_text_id": normalized_text_id,
+            "normalized_url_id": normalized_url_id,
+            "status": "invalid",
+            "action": "ask_user_to_choose",
+            "selected_id": None,
+            "message": (
+                "The arXiv input is invalid. Ask the user for one supported "
+                "arXiv ID or URL before loading a paper."
+            ),
+            "errors": errors,
+        }
+
+    if normalized_text_id is not None and normalized_url_id is not None:
+        if normalized_text_id != normalized_url_id:
+            return {
+                "text_id": text_id,
+                "url": url,
+                "normalized_text_id": normalized_text_id,
+                "normalized_url_id": normalized_url_id,
+                "status": "conflict",
+                "action": "ask_user_to_choose",
+                "selected_id": None,
+                "message": (
+                    "The text arXiv ID and arXiv URL identify different "
+                    "papers. Ask the user which one to analyze before "
+                    "calling load_arxiv_paper."
+                ),
+                "errors": [],
+            }
+        return {
+            "text_id": text_id,
+            "url": url,
+            "normalized_text_id": normalized_text_id,
+            "normalized_url_id": normalized_url_id,
+            "status": "match",
+            "action": "safe_to_load",
+            "selected_id": normalized_text_id,
+            "message": (
+                "The text arXiv ID and arXiv URL identify the same paper. "
+                f"It is safe to load {normalized_text_id}."
+            ),
+            "errors": [],
+        }
+
+    selected_id = normalized_text_id or normalized_url_id
+    return {
+        "text_id": text_id,
+        "url": url,
+        "normalized_text_id": normalized_text_id,
+        "normalized_url_id": normalized_url_id,
+        "status": "single_input",
+        "action": "safe_to_load",
+        "selected_id": selected_id,
+        "message": f"One arXiv input was provided. It is safe to load {selected_id}.",
+        "errors": [],
+    }
 
 
 def _write_response(

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -25,7 +25,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.4.2 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.4.3 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/src/papergraph/diagnostics.py
+++ b/src/papergraph/diagnostics.py
@@ -1,0 +1,63 @@
+"""Runtime diagnostics for first-use PaperGraph setup."""
+
+from __future__ import annotations
+
+import subprocess
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+
+from papergraph.models import DEPENDENCY_EXTRACTION_BASIS
+
+
+PACKAGE_NAME = "papergraph-mcp"
+REPOSITORY_SOURCE = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git"
+
+
+def _git_output(args: list[str], cwd: Path) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _git_context(cwd: Path) -> dict | None:
+    try:
+        top_level = _git_output(["rev-parse", "--show-toplevel"], cwd)
+        commit = _git_output(["rev-parse", "--short=12", "HEAD"], cwd)
+        branch = _git_output(["branch", "--show-current"], cwd)
+        return {
+            "top_level": top_level,
+            "commit": commit,
+            "branch": branch or None,
+        }
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def environment_diagnostics(cwd: Path | None = None) -> dict:
+    """Return deterministic setup information for agents and users."""
+
+    version = distribution_version(PACKAGE_NAME)
+    release_tag = f"v{version}"
+    git = _git_context((cwd or Path.cwd()).resolve())
+    warnings: list[str] = []
+
+    if git is None:
+        warnings.append(
+            "Git context unavailable; use the release-pinned uvx source for "
+            "reproducible first use."
+        )
+
+    return {
+        "package_name": PACKAGE_NAME,
+        "version": version,
+        "release_tag": release_tag,
+        "recommended_source": f"{REPOSITORY_SOURCE}@{release_tag}",
+        "dependency_extraction_basis": DEPENDENCY_EXTRACTION_BASIS,
+        "git": git,
+        "warnings": warnings,
+    }

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import sqlite3
 from collections.abc import Sequence
 from functools import wraps
@@ -9,7 +10,12 @@ from threading import RLock
 from mcp.server import MCPServer
 from mcp.server.mcpserver.exceptions import ToolError
 
-from papergraph.arxiv import ArxivImportError, prepare_arxiv_project
+from papergraph.arxiv import (
+    ArxivImportError,
+    prepare_arxiv_project,
+    validate_arxiv_input as validate_arxiv_input_result,
+)
+from papergraph.diagnostics import environment_diagnostics
 from papergraph.graph import PaperGraph
 from papergraph.identity import paper_id_from_arxiv
 from papergraph.loader import load_latex_project
@@ -80,6 +86,23 @@ def require_workspace() -> Workspace:
             )
 
         return _current_workspace
+
+
+@mcp.tool()
+def get_environment_diagnostics() -> dict:
+    """Return PaperGraph version and reproducible launch diagnostics."""
+
+    return environment_diagnostics()
+
+
+@mcp.tool()
+def validate_arxiv_input(
+    text_id: str | None = None,
+    url: str | None = None,
+) -> dict:
+    """Normalize arXiv ID and URL inputs and return the safe next action."""
+
+    return validate_arxiv_input_result(text_id=text_id, url=url)
 
 
 @mcp.tool()
@@ -438,6 +461,10 @@ def where_used(
     ]
 
 
+def _print_json(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         prog="papergraph-mcp",
@@ -448,7 +475,30 @@ def main(argv: Sequence[str] | None = None) -> None:
         action="version",
         version=f"%(prog)s {distribution_version('papergraph-mcp')}",
     )
-    parser.parse_args(argv)
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser(
+        "doctor",
+        help="Print PaperGraph environment diagnostics as JSON.",
+    )
+    validate_parser = subparsers.add_parser(
+        "validate-arxiv",
+        help="Validate arXiv ID and URL inputs before loading a paper.",
+    )
+    validate_parser.add_argument("--id", dest="text_id")
+    validate_parser.add_argument("--url")
+
+    args = parser.parse_args(argv)
+    if args.command == "doctor":
+        _print_json(environment_diagnostics())
+        return
+    if args.command == "validate-arxiv":
+        _print_json(
+            validate_arxiv_input_result(
+                text_id=args.text_id,
+                url=args.url,
+            )
+        )
+        return
     mcp.run()
 
 

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -13,9 +13,11 @@ from papergraph.arxiv import (
     MainFileSelectionError,
     default_cache_root,
     download_arxiv_source,
+    extract_arxiv_id_from_url,
     normalize_arxiv_id,
     prepare_arxiv_project,
     select_main_file,
+    validate_arxiv_input,
 )
 
 
@@ -53,6 +55,98 @@ def test_normalizes_supported_arxiv_ids(value: str, expected: str):
 def test_rejects_invalid_arxiv_ids(value: str):
     with pytest.raises(InvalidArxivIdError):
         normalize_arxiv_id(value)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://arxiv.org/abs/2609.01574", "2609.01574"),
+        ("https://arxiv.org/abs/2609.01574v2", "2609.01574v2"),
+        ("https://arxiv.org/pdf/math/0307200", "math/0307200"),
+        ("https://export.arxiv.org/abs/hep-th/9901001v3", "hep-th/9901001v3"),
+    ],
+)
+def test_extracts_arxiv_id_from_supported_urls(url: str, expected: str):
+    assert extract_arxiv_id_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "https://example.com/abs/2609.01574",
+        "https://arxiv.org/",
+        "https://arxiv.org/abs/not-an-id",
+        "not a url",
+    ],
+)
+def test_rejects_unsupported_arxiv_urls(url: str):
+    with pytest.raises(InvalidArxivIdError):
+        extract_arxiv_id_from_url(url)
+
+
+def test_validate_arxiv_input_allows_matching_text_and_url():
+    result = validate_arxiv_input(
+        text_id="arXiv:2609.01574",
+        url="https://arxiv.org/abs/2609.01574",
+    )
+
+    assert result == {
+        "text_id": "arXiv:2609.01574",
+        "url": "https://arxiv.org/abs/2609.01574",
+        "normalized_text_id": "2609.01574",
+        "normalized_url_id": "2609.01574",
+        "status": "match",
+        "action": "safe_to_load",
+        "selected_id": "2609.01574",
+        "message": "The text arXiv ID and arXiv URL identify the same paper. It is safe to load 2609.01574.",
+        "errors": [],
+    }
+
+
+def test_validate_arxiv_input_stops_on_conflict():
+    result = validate_arxiv_input(
+        text_id="math/0307200",
+        url="https://arxiv.org/abs/2609.01574",
+    )
+
+    assert result["normalized_text_id"] == "math/0307200"
+    assert result["normalized_url_id"] == "2609.01574"
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert "ask the user" in result["message"].lower()
+    assert result["errors"] == []
+
+
+@pytest.mark.parametrize(
+    ("text_id", "url", "selected"),
+    [
+        ("math/0307200", None, "math/0307200"),
+        (None, "https://arxiv.org/abs/2609.01574", "2609.01574"),
+    ],
+)
+def test_validate_arxiv_input_accepts_single_input(text_id, url, selected):
+    result = validate_arxiv_input(text_id=text_id, url=url)
+
+    assert result["status"] == "single_input"
+    assert result["action"] == "safe_to_load"
+    assert result["selected_id"] == selected
+    assert result["errors"] == []
+
+
+def test_validate_arxiv_input_reports_invalid_inputs_without_selection():
+    result = validate_arxiv_input(
+        text_id="not-an-id",
+        url="https://example.com/abs/2609.01574",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_text_id"] is None
+    assert result["normalized_url_id"] is None
+    assert len(result["errors"]) == 2
 
 
 def test_download_uses_fixed_endpoint_headers_redirects_and_streaming(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 import papergraph.server as server
@@ -17,7 +19,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.4.2\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.4.3\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(
@@ -60,3 +62,52 @@ def test_unknown_argument_is_rejected_without_starting_mcp(
 
     assert caught.value.code == 2
     assert "unrecognized arguments: --unknown" in capsys.readouterr().err
+
+
+def test_doctor_prints_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+    monkeypatch.setattr(
+        server,
+        "environment_diagnostics",
+        lambda: {
+            "package_name": "papergraph-mcp",
+            "version": "0.4.3",
+            "release_tag": "v0.4.3",
+            "recommended_source": (
+                "git+https://github.com/lotchuazzz-crypto/"
+                "papergraph-mcp.git@v0.4.3"
+            ),
+            "dependency_extraction_basis": "statement_explicit_latex_refs_only",
+            "git": None,
+            "warnings": [],
+        },
+    )
+
+    server.main(["doctor"])
+
+    assert json.loads(capsys.readouterr().out)["version"] == "0.4.3"
+
+
+def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+
+    server.main(
+        [
+            "validate-arxiv",
+            "--id",
+            "math/0307200",
+            "--url",
+            "https://arxiv.org/abs/2609.01574",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "conflict"
+    assert payload["action"] == "ask_user_to_choose"
+    assert payload["selected_id"] is None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,30 @@
+from papergraph.diagnostics import environment_diagnostics
+
+
+def test_environment_diagnostics_reports_version_and_release_source():
+    result = environment_diagnostics()
+
+    assert result["package_name"] == "papergraph-mcp"
+    assert result["version"] == "0.4.3"
+    assert result["release_tag"] == "v0.4.3"
+    assert (
+        result["recommended_source"]
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3"
+    )
+    assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
+    assert isinstance(result["warnings"], list)
+
+
+def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
+    import papergraph.diagnostics as diagnostics
+
+    def fail(*_args, **_kwargs):
+        raise OSError("git unavailable")
+
+    monkeypatch.setattr(diagnostics.subprocess, "run", fail)
+
+    result = environment_diagnostics()
+
+    assert result["version"] == "0.4.3"
+    assert result["git"] is None
+    assert any("Git context unavailable" in warning for warning in result["warnings"])

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.2"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.4.2\n"
+        stdout = "papergraph-mcp 0.4.3\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.4.2"
+    assert result["version"] == "papergraph-mcp 0.4.3"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.2"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.3"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -332,7 +332,7 @@ def test_readme_exposes_agent_guided_setup():
     assert ".agents/skills/setting-up-papergraph/SKILL.md" in text
 
 
-def test_all_onboarding_source_pins_match_v042():
+def test_all_onboarding_source_pins_match_v043():
     import re
 
     combined = "\n".join(
@@ -343,4 +343,4 @@ def test_all_onboarding_source_pins_match_v042():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.4.2"}
+    assert set(refs) == {"v0.4.3"}

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -325,6 +325,22 @@ def test_client_reference_discloses_launch_validation_side_effects():
     assert "populate the `uv` cache" in text
 
 
+def test_onboarding_requires_refresh_diagnostics_and_conflict_stop():
+    skill = read(SKILL / "SKILL.md")
+    prompt = read(SKILL / "references" / "usage-prompt.md")
+    client_reference = read(SKILL / "references" / "client-configuration.md")
+
+    assert "git fetch --tags origin" in skill
+    assert "papergraph-mcp doctor" in skill
+    assert "validate_arxiv_input" in skill
+    assert "Call `load_arxiv_paper` only when" in skill
+    assert "detecting a conflict and then continuing is a failure" in skill
+    assert "get_environment_diagnostics" in prompt
+    assert "validate_arxiv_input" in prompt
+    assert "ask_user_to_choose" in prompt
+    assert "papergraph-mcp doctor" in client_reference
+
+
 def test_readme_exposes_agent_guided_setup():
     text = read(ROOT / "README.md")
     assert "Ask your agent to set it up" in text

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -271,6 +271,13 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     assert "display_kind" in readme
     assert "normalized_kind" in readme
     assert "If a prompt contains both an arXiv ID and an arXiv URL" in readme
+    assert "papergraph-mcp doctor" in readme
+    assert "validate-arxiv" in readme
+    assert "`get_environment_diagnostics`" in readme
+    assert "`validate_arxiv_input`" in readme
+    assert "git fetch --tags origin" in readme
+    assert "Call `load_arxiv_paper` only when" in readme
+    assert "detecting a conflict and then continuing is a failure" in readme
 
     assert 'arxiv_id="math/0307200"' in readme
     assert '"path": "main.tex"' in readme

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -21,7 +21,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.4.2"
+    assert project["version"] == "0.4.3"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -65,7 +65,7 @@ def test_lockfile_matches_project_version():
         if package["name"] == "papergraph-mcp"
     )
 
-    assert package["version"] == "0.4.2"
+    assert package["version"] == "0.4.3"
 
 
 def test_runtime_and_issue_template_release_strings_match_project_version():
@@ -120,7 +120,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.4.2" in build_steps
+    assert "papergraph-mcp 0.4.3" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -228,7 +228,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.4.2"
+        "papergraph-mcp.git@v0.4.3"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):
@@ -239,7 +239,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     )
     assert '"command": "uvx"' in readme
     assert pinned_source in readme
-    assert "PaperGraph v0.4.2" in readme
+    assert "PaperGraph v0.4.3" in readme
 
     for tool_name in (
         "load_paper",
@@ -301,7 +301,7 @@ def test_readme_documents_v040_cross_paper_graph_history():
     assert "semantic" in readme.lower()
 
 
-def test_onboarding_uses_v042_release_pin_and_mentions_id_url_conflicts():
+def test_onboarding_uses_v043_release_pin_and_mentions_id_url_conflicts():
     skill = (
         ROOT / ".agents/skills/setting-up-papergraph/SKILL.md"
     ).read_text(encoding="utf-8")
@@ -309,8 +309,9 @@ def test_onboarding_uses_v042_release_pin_and_mentions_id_url_conflicts():
         ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
     ).read_text(encoding="utf-8")
 
-    assert "papergraph-mcp.git@v0.4.2" in skill
-    assert "papergraph-mcp 0.4.2" in skill
+    assert "papergraph-mcp.git@v0.4.3" in skill
+    assert "papergraph-mcp 0.4.3" in skill
+    assert "validate_arxiv_input" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill
     assert "ask which one to analyze" in skill
     assert "arXiv ID and arXiv URL" in prompt

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -163,6 +163,38 @@ def test_missing_graph_message_mentions_both_load_tools():
     assert "load_arxiv_paper" in message
 
 
+def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "environment_diagnostics",
+        lambda: {
+            "package_name": "papergraph-mcp",
+            "version": "0.4.3",
+            "release_tag": "v0.4.3",
+            "recommended_source": (
+                "git+https://github.com/lotchuazzz-crypto/"
+                "papergraph-mcp.git@v0.4.3"
+            ),
+            "dependency_extraction_basis": "statement_explicit_latex_refs_only",
+            "git": None,
+            "warnings": [],
+        },
+    )
+
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.4.3"
+
+
+def test_validate_arxiv_input_tool_reports_conflict():
+    result = server.validate_arxiv_input(
+        text_id="math/0307200",
+        url="https://arxiv.org/abs/2609.01574",
+    )
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+
+
 def test_get_dependency_diagnostics_reports_single_paper_basis(tmp_path: Path):
     local = tmp_path / "local.tex"
     local.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump PaperGraph release surfaces to `0.4.3` / `v0.4.3`.
- Add arXiv ID/URL validation with conflict-stop behavior through core helpers, CLI, and MCP.
- Add environment diagnostics through `papergraph-mcp doctor` and `get_environment_diagnostics`.
- Update README and onboarding guidance so agents refresh stale clones, verify the running version, validate arXiv conflicts, and stop before loading on conflicts.

## Testing
- `.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider` -> `280 passed, 1 skipped`
- `.\.venv\Scripts\papergraph-mcp.exe --version` -> `papergraph-mcp 0.4.3`
- `.\.venv\Scripts\papergraph-mcp.exe doctor`
- `.\.venv\Scripts\papergraph-mcp.exe validate-arxiv --id math/0307200 --url https://arxiv.org/abs/2609.01574` -> `status: conflict`, `action: ask_user_to_choose`
- `git diff --check`