### PR TITLE
Add high-level arXiv request loading for v0.4.4

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -46,23 +46,23 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.4.3`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.4.4`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp --version
 ```
 
 The expected output is:
 
 ```text
-papergraph-mcp 0.4.3
+papergraph-mcp 0.4.4
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -21,9 +21,10 @@ Before loading arXiv papers:
 
 1. If a repository directory already exists, run `git fetch --tags origin` before trusting local `origin/main`.
 2. Verify `papergraph-mcp --version` and run `papergraph-mcp doctor` or call `get_environment_diagnostics`.
-3. If a user provides both an arXiv ID and an arXiv URL, call `validate_arxiv_input` first.
-4. Call `load_arxiv_paper` only when `validate_arxiv_input` returns `action: safe_to_load`.
-5. If validation returns `action: ask_user_to_choose`, stop and ask which one to analyze. detecting a conflict and then continuing is a failure.
+3. For raw user wording, Markdown links, URLs, or prose, call `validate_arxiv_request` or `load_arxiv_request`.
+4. If a user provides both an arXiv ID and an arXiv URL, `load_arxiv_request` must stop before loading unless they identify the same paper.
+5. Use `load_arxiv_paper` only after the user has provided one already-disambiguated arXiv ID.
+6. If validation returns `action: ask_user_to_choose`, stop and ask which one to analyze. detecting a conflict and then continuing is a failure.
 
 ### What is missing
 

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.agents/skills/setting-up-papergraph/references/usage-prompt.md
+++ b/.agents/skills/setting-up-papergraph/references/usage-prompt.md
@@ -9,7 +9,7 @@ Present this prompt before asking for installation permission:
 
 开始分析前，请先调用 `get_environment_diagnostics` 或运行 `papergraph-mcp doctor`，并在回答里说明 PaperGraph 版本。
 
-如果我同时给出 arXiv ID and arXiv URL，请先调用 `validate_arxiv_input` 或 `papergraph-mcp validate-arxiv`。只有当结果是 `action: safe_to_load` 时才调用 `load_arxiv_paper`；如果结果是 `action: ask_user_to_choose`，请先问我要分析哪一篇，不要继续加载。
+如果我给出原始请求、Markdown 链接、arXiv ID and arXiv URL 或混合文本，请优先调用 `load_arxiv_request`，或先调用 `validate_arxiv_request` / `papergraph-mcp validate-arxiv-request` 查看判定。只有当验证结果是 `action: safe_to_load` 时才加载；如果结果是 `action: ask_user_to_choose`，请先问我要分析哪一篇，不要继续加载。只有在我已经给出单一、无歧义的 arXiv ID 后，才直接调用 `load_arxiv_paper`。
 
 1. 列出成功导入的论文；
 2. 搜索与“fixed point”相关的定理；

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.4.3"
+      placeholder: "0.4.4"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.4.3"
+          test "$version" = "papergraph-mcp 0.4.4"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/lotchuazzz-crypto/papergraph-mcp)](https://github.com/lotchuazzz-crypto/papergraph-mcp/releases)
 
-PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.3 hardens first-use analysis by making agents verify the running version, validate arXiv ID/URL pairs, and report dependency boundaries before interpreting sparse graphs.
+PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.4 hardens first-use analysis by making agents verify the running version, validate arXiv ID/URL pairs, and report dependency boundaries before interpreting sparse graphs.
 
 PaperGraph v0.4.0 introduced the persistent, cross-paper SQLite workspace: retain a small literature collection, search theorem text, follow theorem dependencies, and inspect citation evidence without asking an agent to re-read every source paper.
 
@@ -46,11 +46,11 @@ returns `action: ask_user_to_choose`, ask the user to choose; detecting a confli
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the GitHub release without cloning the repository:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
-The pinned command becomes available after the `v0.4.3` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.4.4` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 To validate conflicting arXiv input before loading a paper, run:
 
@@ -67,7 +67,7 @@ For an MCP client that accepts JSON-style stdio server configuration, add:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4", "papergraph-mcp"]
     }
   }
 }
@@ -98,7 +98,7 @@ For a compact single-paper check, call `load_arxiv_paper(arxiv_id="math/0307200"
 
 ## Reading Sparse Dependency Results
 
-PaperGraph v0.4.3 dependency traversal uses `statement_explicit_latex_refs_only`:
+PaperGraph v0.4.4 dependency traversal uses `statement_explicit_latex_refs_only`:
 it follows explicit LaTeX references such as `\ref`, `\eqref`, `\autoref`,
 `\cref`, and `\Cref` inside theorem-like statements. An empty dependency result
 means PaperGraph found no resolvable theorem-label references under that rule.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/lotchuazzz-crypto/papergraph-mcp)](https://github.com/lotchuazzz-crypto/papergraph-mcp/releases)
 
-PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.4 hardens first-use analysis by making agents verify the running version, validate arXiv ID/URL pairs, and report dependency boundaries before interpreting sparse graphs.
+PaperGraph turns local or arXiv LaTeX papers into theorem dependency graphs that AI agents can query through MCP. PaperGraph v0.4.4 hardens first-use analysis by making agents verify the running version, validate raw arXiv requests, and report dependency boundaries before interpreting sparse graphs.
 
 PaperGraph v0.4.0 introduced the persistent, cross-paper SQLite workspace: retain a small literature collection, search theorem text, follow theorem dependencies, and inspect citation evidence without asking an agent to re-read every source paper.
 
@@ -37,9 +37,12 @@ If your agent clones into a directory that already exists, ask it to run
 `git fetch --tags origin` before treating the checkout as current. Existing
 clones can otherwise remain pinned to an old local `origin/main`.
 
-If a prompt contains both an arXiv ID and an arXiv URL, ask the agent to call
-`validate_arxiv_input` or `papergraph-mcp validate-arxiv` before loading. Call `load_arxiv_paper` only when the validator returns `action: safe_to_load`. If it
-returns `action: ask_user_to_choose`, ask the user to choose; detecting a conflict and then continuing is a failure.
+For raw user requests, prefer `load_arxiv_request(input=...)` or
+`papergraph-mcp load-arxiv-request "..."`. These high-level entry points
+validate bare IDs, URLs, Markdown links, and prose before loading. To inspect
+the decision without loading, call `validate_arxiv_request` or
+`papergraph-mcp validate-arxiv-request "..."`. If validation returns
+`action: ask_user_to_choose`, ask the user to choose; detecting a conflict and then continuing is a failure. Use `load_arxiv_paper` only after the user has provided one already-disambiguated arXiv ID.
 
 ## Quick Start
 
@@ -52,10 +55,10 @@ papergraph-mcp doctor
 
 The pinned command becomes available after the `v0.4.4` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
-To validate conflicting arXiv input before loading a paper, run:
+To validate a raw arXiv request before loading a paper, run:
 
 ```powershell
-papergraph-mcp validate-arxiv --id math/0307200 --url https://arxiv.org/abs/2609.01574
+papergraph-mcp validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"
 ```
 
 ## MCP Configuration
@@ -77,7 +80,7 @@ Restart the MCP client after changing its configuration. The server uses stdio, 
 
 ## Tools
 
-The original single-paper tools remain available: `get_environment_diagnostics`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`. Their signatures are `get_environment_diagnostics()`, `validate_arxiv_input(text_id: str | None = None, url: str | None = None)`, `load_paper(path: str)`, `load_arxiv_paper(arxiv_id: str, main_file: str | None = None, refresh: bool = False)`, `list_theorems(kind: str | None = None)`, `get_theorem(theorem_id: str)`, `get_dependencies(theorem_id: str, recursive: bool = False)`, `get_dependency_diagnostics(theorem_id: str, recursive: bool = False)`, and `where_used(theorem_id: str)`.
+The original single-paper tools remain available: `get_environment_diagnostics`, `validate_arxiv_request`, `load_arxiv_request`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`. Their signatures are `get_environment_diagnostics()`, `validate_arxiv_request(input: str)`, `load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False)`, `validate_arxiv_input(text_id: str | None = None, url: str | None = None)`, `load_paper(path: str)`, `load_arxiv_paper(arxiv_id: str, main_file: str | None = None, refresh: bool = False)`, `list_theorems(kind: str | None = None)`, `get_theorem(theorem_id: str)`, `get_dependencies(theorem_id: str, recursive: bool = False)`, `get_dependency_diagnostics(theorem_id: str, recursive: bool = False)`, and `where_used(theorem_id: str)`.
 
 Workspace tools operate on the active database. Call `open_workspace` first: `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, and `workspace_get_citations` require that active workspace. Their exact MCP signatures and return summaries are:
 
@@ -94,7 +97,7 @@ Workspace tools operate on the active database. Call `open_workspace` first: `wo
 | `workspace_get_dependency_diagnostics(global_theorem_id: str, recursive: bool = False) -> dict` | The same diagnostic contract for a globally identified theorem in the active workspace. |
 | `workspace_get_citations(paper_id: str, direction: str = "outgoing", include_unresolved: bool = True) -> list[dict]` | Explicit incoming or outgoing citation-evidence rows. Direction is `incoming` or `outgoing`; incoming rows are resolved. |
 
-For a compact single-paper check, call `load_arxiv_paper(arxiv_id="math/0307200")`. PaperGraph selects `main.tex`; a representative first response has `"path": "main.tex"`, `"cached": false`, and `"nodes": 7`.
+For a compact single-paper check with an already-disambiguated ID, call `load_arxiv_paper(arxiv_id="math/0307200")`. For ordinary user text, call `load_arxiv_request(input="math/0307200")`. PaperGraph selects `main.tex`; a representative first response has `"path": "main.tex"`, `"cached": false`, and `"nodes": 7`.
 
 ## Reading Sparse Dependency Results
 

--- a/docs/superpowers/plans/2026-09-03-v0.4.4-unified-arxiv-request.md
+++ b/docs/superpowers/plans/2026-09-03-v0.4.4-unified-arxiv-request.md
@@ -1,0 +1,976 @@
+# PaperGraph v0.4.4 Unified arXiv Request Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add high-level arXiv request validation and loading tools that accept raw user text or Markdown links and refuse conflicting requests before any paper load.
+
+**Architecture:** Keep v0.4.3 low-level APIs intact. Extend `src/papergraph/arxiv.py` with raw-request extraction and validation, then expose it through `src/papergraph/server.py` by wrapping the existing safe `load_arxiv_paper` pipeline. Update docs so first-use agents prefer `load_arxiv_request`.
+
+**Tech Stack:** Python 3.10+, regex, urllib.parse, argparse, MCPServer decorators, pytest, existing PaperGraph parser/loader/graph modules.
+
+## Global Constraints
+
+- Target release is exactly `0.4.4` / `v0.4.4`.
+- Do not remove or change `validate_arxiv_input`.
+- Do not remove or change `load_arxiv_paper`.
+- Do not change single-paper graph state unless high-level request loading succeeds.
+- Do not introduce network-dependent tests.
+- Do not infer main theorem status or semantic theorem dependencies in this release.
+- Do not create tags, publish releases, merge PRs, delete branches, clean up worktrees, or modify `D:\August\papergraph-mcp` without explicit user approval.
+
+---
+
+## File Structure
+
+- `src/papergraph/arxiv.py`: add raw request extraction helpers and `validate_arxiv_request(input: str) -> dict`.
+- `src/papergraph/server.py`: add shared arXiv project loading helper, MCP tools, and CLI commands for request validation/loading.
+- `tests/test_arxiv.py`: cover raw request validation and candidate evidence.
+- `tests/test_server.py`: cover MCP request tools and active graph preservation on conflict.
+- `tests/test_cli.py`: cover CLI request commands and nonzero conflict exit.
+- `tests/test_repository.py`: update version and README expectations.
+- `tests/test_onboarding.py`: update pin/version and onboarding expectations.
+- `pyproject.toml`, `uv.lock`, `src/papergraph/arxiv.py`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/workflows/ci.yml`, `scripts/check_onboarding.py`, `README.md`, `.agents/skills/setting-up-papergraph/*`: update release surfaces and first-use guidance.
+
+---
+
+### Task 1: v0.4.4 Version Baseline
+
+**Files:**
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_diagnostics.py`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `scripts/check_onboarding.py`
+- Modify: `README.md`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+
+**Interfaces:**
+- Consumes: existing version tests and release pin strings.
+- Produces: all active release surfaces consistently use `0.4.4` / `v0.4.4`.
+
+- [ ] **Step 1: Write failing version tests**
+
+Update exact version expectations:
+
+```python
+# tests/test_repository.py
+assert project["version"] == "0.4.4"
+assert package["version"] == "0.4.4"
+assert "papergraph-mcp 0.4.4" in build_steps
+assert "papergraph-mcp.git@v0.4.4" in pinned_source
+assert "PaperGraph v0.4.4" in readme
+assert "papergraph-mcp.git@v0.4.4" in skill
+assert "papergraph-mcp 0.4.4" in skill
+```
+
+```python
+# tests/test_onboarding.py
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4"
+stdout = "papergraph-mcp 0.4.4\n"
+launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.4"}
+assert set(refs) == {"v0.4.4"}
+```
+
+```python
+# tests/test_cli.py
+assert capsys.readouterr().out == "papergraph-mcp 0.4.4\n"
+```
+
+```python
+# tests/test_diagnostics.py
+assert result["version"] == "0.4.4"
+assert result["release_tag"] == "v0.4.4"
+assert result["recommended_source"] == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4"
+```
+
+- [ ] **Step 2: Run version tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py tests/test_cli.py tests/test_diagnostics.py -q -p no:cacheprovider
+```
+
+Expected: FAIL because source files still contain `0.4.3` / `v0.4.3`.
+
+- [ ] **Step 3: Update version surfaces**
+
+Update active files:
+
+```toml
+# pyproject.toml
+version = "0.4.4"
+```
+
+```python
+# src/papergraph/arxiv.py
+_USER_AGENT = "PaperGraph/0.4.4 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+```
+
+Update `.github/ISSUE_TEMPLATE/bug_report.yml`:
+
+```yaml
+placeholder: "0.4.4"
+```
+
+Update `.github/workflows/ci.yml`:
+
+```bash
+test "$version" = "papergraph-mcp 0.4.4"
+```
+
+Update `scripts/check_onboarding.py` constants to `0.4.4` / `v0.4.4`.
+
+Update README and onboarding pins/prose from `0.4.3` / `v0.4.3` to `0.4.4` / `v0.4.4`.
+
+Refresh editable package metadata:
+
+```powershell
+.\.venv\Scripts\python.exe -m pip install --no-deps -e .
+```
+
+- [ ] **Step 4: Run version tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py tests/test_cli.py tests/test_diagnostics.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add pyproject.toml uv.lock src/papergraph/arxiv.py .github/ISSUE_TEMPLATE/bug_report.yml .github/workflows/ci.yml scripts/check_onboarding.py README.md .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/client-configuration.md tests/test_repository.py tests/test_onboarding.py tests/test_cli.py tests/test_diagnostics.py
+git commit -m "Prepare v0.4.4 version baseline"
+```
+
+---
+
+### Task 2: Raw arXiv Request Validation Core
+
+**Files:**
+- Modify: `tests/test_arxiv.py`
+- Modify: `src/papergraph/arxiv.py`
+
+**Interfaces:**
+- Consumes:
+  - `normalize_arxiv_id(value: str) -> str`
+  - `extract_arxiv_id_from_url(url: str) -> str`
+  - `InvalidArxivIdError`
+- Produces:
+  - `validate_arxiv_request(input: str) -> dict`
+
+- [ ] **Step 1: Add failing raw request validation tests**
+
+In `tests/test_arxiv.py`, extend the import:
+
+```python
+from papergraph.arxiv import validate_arxiv_request
+```
+
+Add:
+
+```python
+@pytest.mark.parametrize(
+    ("request", "selected", "status"),
+    [
+        ("2609.02842", "2609.02842", "single_input"),
+        ("Please load math/0307200", "math/0307200", "single_input"),
+        ("https://arxiv.org/abs/2609.01574", "2609.01574", "single_input"),
+        (
+            "[math/0307200](https://arxiv.org/abs/math/0307200)",
+            "math/0307200",
+            "match",
+        ),
+    ],
+)
+def test_validate_arxiv_request_accepts_single_or_matching_requests(request, selected, status):
+    result = validate_arxiv_request(request)
+
+    assert result["status"] == status
+    assert result["action"] == "safe_to_load"
+    assert result["selected_id"] == selected
+    assert result["normalized_ids"] == [selected]
+    assert result["errors"] == []
+    assert result["candidates"]
+```
+
+Add conflict tests:
+
+```python
+def test_validate_arxiv_request_stops_conflicting_markdown_link():
+    result = validate_arxiv_request(
+        "[math/0307200](https://arxiv.org/abs/2609.01574)"
+    )
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_ids"] == ["math/0307200", "2609.01574"]
+    assert [candidate["kind"] for candidate in result["candidates"]] == [
+        "markdown_text",
+        "markdown_url",
+    ]
+
+
+def test_validate_arxiv_request_stops_prose_id_url_conflict():
+    result = validate_arxiv_request(
+        "Load math/0307200 from https://arxiv.org/abs/2609.01574"
+    )
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_ids"] == ["math/0307200", "2609.01574"]
+```
+
+Add invalid and non-arXiv URL tests:
+
+```python
+def test_validate_arxiv_request_reports_invalid_empty_input():
+    result = validate_arxiv_request("   ")
+
+    assert result["status"] == "invalid"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["candidates"] == []
+    assert result["errors"]
+
+
+def test_validate_arxiv_request_ignores_non_arxiv_url_when_valid_id_exists():
+    result = validate_arxiv_request(
+        "Load 2609.02842 and see https://example.com/notes"
+    )
+
+    assert result["status"] == "single_input"
+    assert result["action"] == "safe_to_load"
+    assert result["selected_id"] == "2609.02842"
+    assert result["errors"] == []
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_arxiv.py -q -p no:cacheprovider
+```
+
+Expected: FAIL importing `validate_arxiv_request`.
+
+- [ ] **Step 3: Implement raw request validation**
+
+In `src/papergraph/arxiv.py`, add regex constants near the existing ID regexes:
+
+```python
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+_URL_RE = re.compile(r"https?://[^\s)\]]+")
+_ARXIV_ID_SEARCH_RE = re.compile(
+    r"(?<![A-Za-z0-9./:-])(?:arXiv:)?(?:\d{4}\.\d{4,5}(?:v[1-9]\d*)?|[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?)(?![A-Za-z0-9.-])",
+    re.IGNORECASE,
+)
+```
+
+Add helper functions after `validate_arxiv_input`:
+
+```python
+def _candidate(
+    kind: str,
+    value: str,
+    normalized_id: str | None,
+    source: str,
+) -> dict:
+    return {
+        "kind": kind,
+        "value": value,
+        "normalized_id": normalized_id,
+        "source": source,
+    }
+
+
+def _append_unique_normalized_id(ids: list[str], candidate: dict) -> None:
+    normalized_id = candidate["normalized_id"]
+    if normalized_id is not None and normalized_id not in ids:
+        ids.append(normalized_id)
+
+
+def _extract_request_candidates(input_text: str) -> tuple[list[dict], list[str]]:
+    candidates: list[dict] = []
+    errors: list[str] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    for match in _MARKDOWN_LINK_RE.finditer(input_text):
+        visible_text, url = match.groups()
+        consumed_spans.append(match.span())
+        try:
+            text_id = normalize_arxiv_id(visible_text)
+            candidates.append(_candidate("markdown_text", visible_text, text_id, "markdown"))
+        except InvalidArxivIdError:
+            pass
+        try:
+            url_id = extract_arxiv_id_from_url(url)
+            candidates.append(_candidate("markdown_url", url, url_id, "markdown"))
+        except InvalidArxivIdError as exc:
+            errors.append(str(exc))
+
+    def is_consumed(start: int, end: int) -> bool:
+        return any(start >= span_start and end <= span_end for span_start, span_end in consumed_spans)
+
+    for match in _URL_RE.finditer(input_text):
+        if is_consumed(*match.span()):
+            continue
+        url = match.group(0)
+        try:
+            candidates.append(
+                _candidate("plain_url", url, extract_arxiv_id_from_url(url), "text")
+            )
+        except InvalidArxivIdError:
+            pass
+
+    for match in _ARXIV_ID_SEARCH_RE.finditer(input_text):
+        if is_consumed(*match.span()):
+            continue
+        value = match.group(0)
+        try:
+            candidates.append(
+                _candidate("bare_id", value, normalize_arxiv_id(value), "text")
+            )
+        except InvalidArxivIdError as exc:
+            errors.append(str(exc))
+
+    return candidates, errors
+
+
+def validate_arxiv_request(input: str) -> dict:
+    """Validate raw user arXiv request text and return the safe next action."""
+
+    if not isinstance(input, str):
+        input_text = ""
+        errors = ["arXiv request input must be text"]
+        candidates: list[dict] = []
+    else:
+        input_text = input
+        candidates, errors = _extract_request_candidates(input_text)
+
+    normalized_ids: list[str] = []
+    for candidate in candidates:
+        _append_unique_normalized_id(normalized_ids, candidate)
+
+    if not normalized_ids:
+        if not errors:
+            errors.append("Provide an arXiv ID, arXiv URL, or Markdown arXiv link.")
+        return {
+            "input": input,
+            "candidates": candidates,
+            "normalized_ids": normalized_ids,
+            "status": "invalid",
+            "action": "ask_user_to_choose",
+            "selected_id": None,
+            "message": "No supported arXiv identifier was found. Ask the user for one arXiv ID or URL before loading a paper.",
+            "errors": errors,
+        }
+
+    if len(normalized_ids) > 1:
+        return {
+            "input": input,
+            "candidates": candidates,
+            "normalized_ids": normalized_ids,
+            "status": "conflict",
+            "action": "ask_user_to_choose",
+            "selected_id": None,
+            "message": "The request contains multiple different arXiv identifiers. Ask the user which one to analyze before loading a paper.",
+            "errors": errors,
+        }
+
+    status = "match" if len(candidates) > 1 else "single_input"
+    return {
+        "input": input,
+        "candidates": candidates,
+        "normalized_ids": normalized_ids,
+        "status": status,
+        "action": "safe_to_load",
+        "selected_id": normalized_ids[0],
+        "message": f"The request identifies one arXiv paper. It is safe to load {normalized_ids[0]}.",
+        "errors": errors,
+    }
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_arxiv.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/arxiv.py tests/test_arxiv.py
+git commit -m "Add raw arXiv request validation"
+```
+
+---
+
+### Task 3: High-Level MCP Load Tool
+
+**Files:**
+- Modify: `tests/test_server.py`
+- Modify: `src/papergraph/server.py`
+
+**Interfaces:**
+- Consumes:
+  - `validate_arxiv_request(input: str) -> dict`
+  - existing `prepare_arxiv_project`, `load_latex_project`, `parse_latex`, and `PaperGraph`
+- Produces:
+  - `validate_arxiv_request(input: str) -> dict` MCP tool
+  - `load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False) -> dict` MCP tool
+
+- [ ] **Step 1: Add failing MCP tests**
+
+In `tests/test_server.py`, add:
+
+```python
+def test_validate_arxiv_request_tool_reports_markdown_conflict():
+    result = server.validate_arxiv_request(
+        "[math/0307200](https://arxiv.org/abs/2609.01574)"
+    )
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+
+
+def test_load_arxiv_request_loads_valid_request_and_includes_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    project = make_multifile_project(tmp_path)
+    monkeypatch.setattr(server, "prepare_arxiv_project", lambda *args, **kwargs: project)
+
+    result = server.load_arxiv_request("Load https://arxiv.org/abs/2401.12345")
+
+    assert result["arxiv_id"] == "2401.12345"
+    assert result["nodes"] == 2
+    assert result["request_validation"]["status"] == "single_input"
+    assert result["request_validation"]["selected_id"] == "2401.12345"
+
+
+def test_load_arxiv_request_conflict_preserves_active_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    local = tmp_path / "local.tex"
+    local.write_text(
+        "\\newtheorem{lemma}{Lemma}\n"
+        "\\begin{lemma}Local.\\label{lem:local}\\end{lemma}",
+        encoding="utf-8",
+    )
+    server.load_paper(str(local))
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("conflicting request must not prepare an arXiv project")
+
+    monkeypatch.setattr(server, "prepare_arxiv_project", fail_if_called)
+
+    with pytest.raises(ToolError, match="multiple different arXiv"):
+        server.load_arxiv_request(
+            "[math/0307200](https://arxiv.org/abs/2609.01574)"
+        )
+
+    assert [node["id"] for node in server.list_theorems()] == ["lem:local"]
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_server.py -q -p no:cacheprovider
+```
+
+Expected: FAIL because the new MCP functions are missing.
+
+- [ ] **Step 3: Refactor server loading helper and add tools**
+
+In `src/papergraph/server.py`, update imports:
+
+```python
+from papergraph.arxiv import (
+    ArxivImportError,
+    prepare_arxiv_project,
+    validate_arxiv_input as validate_arxiv_input_result,
+    validate_arxiv_request as validate_arxiv_request_result,
+)
+```
+
+Add a shared helper above `load_arxiv_paper`:
+
+```python
+def _load_prepared_arxiv_project(
+    arxiv_id: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+) -> dict:
+    global _current_graph
+    global _current_path
+
+    project = prepare_arxiv_project(
+        arxiv_id,
+        main_file,
+        refresh,
+    )
+    text = load_latex_project(project.main_file)
+    nodes = parse_latex(text)
+    graph = PaperGraph(nodes)
+
+    kinds: dict[str, int] = {}
+    for node in nodes:
+        kinds[node.kind] = kinds.get(node.kind, 0) + 1
+
+    _current_graph = graph
+    _current_path = project.main_file
+
+    return {
+        "arxiv_id": project.arxiv_id,
+        "path": str(project.main_file),
+        "cached": project.cached,
+        "nodes": len(nodes),
+        "kinds": kinds,
+    }
+```
+
+Replace `load_arxiv_paper` body with:
+
+```python
+try:
+    return _load_prepared_arxiv_project(arxiv_id, main_file, refresh)
+except (ArxivImportError, OSError, ValueError) as exc:
+    raise ToolError(str(exc)) from exc
+```
+
+Add MCP tools:
+
+```python
+@mcp.tool()
+def validate_arxiv_request(input: str) -> dict:
+    """Validate raw arXiv request text and return the safe next action."""
+
+    return validate_arxiv_request_result(input)
+
+
+@mcp.tool()
+def load_arxiv_request(
+    input: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+) -> dict:
+    """Validate and load an arXiv request from raw user text."""
+
+    validation = validate_arxiv_request_result(input)
+    if validation["action"] != "safe_to_load":
+        raise ToolError(validation["message"])
+    try:
+        result = _load_prepared_arxiv_project(
+            validation["selected_id"],
+            main_file,
+            refresh,
+        )
+    except (ArxivImportError, OSError, ValueError) as exc:
+        raise ToolError(str(exc)) from exc
+    return {**result, "request_validation": validation}
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_server.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_server.py
+git commit -m "Add high-level arXiv request MCP tools"
+```
+
+---
+
+### Task 4: CLI Request Commands
+
+**Files:**
+- Modify: `tests/test_cli.py`
+- Modify: `src/papergraph/server.py`
+
+**Interfaces:**
+- Consumes:
+  - `validate_arxiv_request_result(input: str) -> dict`
+  - `load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False) -> dict`
+- Produces:
+  - `papergraph-mcp validate-arxiv-request <input>`
+  - `papergraph-mcp load-arxiv-request <input> [--main-file ...] [--refresh]`
+
+- [ ] **Step 1: Add failing CLI tests**
+
+In `tests/test_cli.py`, add:
+
+```python
+def test_validate_arxiv_request_cli_prints_conflict_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+
+    server.main(
+        [
+            "validate-arxiv-request",
+            "[math/0307200](https://arxiv.org/abs/2609.01574)",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "conflict"
+    assert payload["action"] == "ask_user_to_choose"
+    assert payload["selected_id"] is None
+
+
+def test_load_arxiv_request_cli_conflict_exits_nonzero_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+
+    with pytest.raises(SystemExit) as caught:
+        server.main(
+            [
+                "load-arxiv-request",
+                "[math/0307200](https://arxiv.org/abs/2609.01574)",
+            ]
+        )
+
+    assert caught.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "conflict"
+    assert payload["action"] == "ask_user_to_choose"
+
+
+def test_load_arxiv_request_cli_success_prints_load_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+    monkeypatch.setattr(
+        server,
+        "load_arxiv_request",
+        lambda input, main_file=None, refresh=False: {
+            "arxiv_id": "2609.02842",
+            "path": "Harsh.tex",
+            "cached": True,
+            "nodes": 31,
+            "kinds": {"theorem": 9},
+            "request_validation": {
+                "status": "single_input",
+                "selected_id": "2609.02842",
+            },
+        },
+    )
+
+    server.main(["load-arxiv-request", "2609.02842"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["arxiv_id"] == "2609.02842"
+    assert payload["request_validation"]["selected_id"] == "2609.02842"
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_cli.py -q -p no:cacheprovider
+```
+
+Expected: FAIL because the new subcommands are missing.
+
+- [ ] **Step 3: Implement CLI subcommands**
+
+In `src/papergraph/server.py`, add subparsers in `main`:
+
+```python
+request_validate_parser = subparsers.add_parser(
+    "validate-arxiv-request",
+    help="Validate raw arXiv request text before loading a paper.",
+)
+request_validate_parser.add_argument("input")
+
+request_load_parser = subparsers.add_parser(
+    "load-arxiv-request",
+    help="Validate and load raw arXiv request text.",
+)
+request_load_parser.add_argument("input")
+request_load_parser.add_argument("--main-file")
+request_load_parser.add_argument("--refresh", action="store_true")
+```
+
+Add handling after `validate-arxiv`:
+
+```python
+if args.command == "validate-arxiv-request":
+    _print_json(validate_arxiv_request_result(args.input))
+    return
+if args.command == "load-arxiv-request":
+    validation = validate_arxiv_request_result(args.input)
+    if validation["action"] != "safe_to_load":
+        _print_json(validation)
+        raise SystemExit(1)
+    _print_json(
+        load_arxiv_request(
+            args.input,
+            main_file=args.main_file,
+            refresh=args.refresh,
+        )
+    )
+    return
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_cli.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_cli.py
+git commit -m "Add arXiv request CLI commands"
+```
+
+---
+
+### Task 5: Documentation and Onboarding Defaults
+
+**Files:**
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+- Modify: `README.md`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/usage-prompt.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+
+**Interfaces:**
+- Consumes:
+  - `validate_arxiv_request`
+  - `load_arxiv_request`
+  - CLI `validate-arxiv-request`
+  - CLI `load-arxiv-request`
+- Produces: first-use docs that recommend the high-level raw request tools and label `load_arxiv_paper` as confirmed-ID only.
+
+- [ ] **Step 1: Add failing documentation tests**
+
+In `tests/test_repository.py`, extend README assertions:
+
+```python
+assert "`validate_arxiv_request`" in readme
+assert "`load_arxiv_request`" in readme
+assert "validate-arxiv-request" in readme
+assert "load-arxiv-request" in readme
+assert 'load_arxiv_request(input="math/0307200")' in readme
+assert "Use `load_arxiv_paper` only after the intended ID is already confirmed" in readme
+```
+
+In `tests/test_onboarding.py`, extend `test_onboarding_requires_refresh_diagnostics_and_conflict_stop`:
+
+```python
+assert "validate_arxiv_request" in skill
+assert "load_arxiv_request" in skill
+assert "validate-arxiv-request" in prompt
+assert "load_arxiv_request" in prompt
+assert "calls `load_arxiv_paper` anyway" in skill
+assert "Use `load_arxiv_paper` only after the intended ID is already confirmed" in skill
+```
+
+- [ ] **Step 2: Run documentation tests and verify they fail**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: FAIL until docs recommend high-level request tools.
+
+- [ ] **Step 3: Update README**
+
+Update intro:
+
+```markdown
+PaperGraph v0.4.4 hardens first-use analysis by letting agents pass raw arXiv request text or Markdown links to a high-level loading tool that refuses conflicting identifiers.
+```
+
+Update first-use guidance to say:
+
+```markdown
+For raw user prompts, prefer `validate_arxiv_request` and `load_arxiv_request`. They inspect bare IDs, arXiv URLs, and Markdown links before loading. Use `load_arxiv_paper` only after the intended ID is already confirmed.
+```
+
+Update Quick Start examples:
+
+```powershell
+papergraph-mcp validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"
+papergraph-mcp load-arxiv-request "2609.02842"
+```
+
+Update Tools list to include:
+
+```markdown
+`validate_arxiv_request(input: str)`, `load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False)`
+```
+
+Replace the compact single-paper check with:
+
+```markdown
+For a compact single-paper check, call `load_arxiv_request(input="math/0307200")`.
+```
+
+- [ ] **Step 4: Update onboarding skill and prompt**
+
+In `.agents/skills/setting-up-papergraph/SKILL.md`, update arXiv loading rules:
+
+```markdown
+For raw user prompts, call `validate_arxiv_request` or `load_arxiv_request`. Use `load_arxiv_paper` only after the intended ID is already confirmed.
+
+If an agent notices a Markdown ID/URL conflict and calls `load_arxiv_paper` anyway, that is a failure.
+```
+
+In `.agents/skills/setting-up-papergraph/references/usage-prompt.md`, update the prompt:
+
+```markdown
+如果我给出原始 arXiv 文本、URL 或 Markdown 链接，请优先调用 `validate_arxiv_request` 或 `load_arxiv_request`。也可以运行 `papergraph-mcp validate-arxiv-request`。只有当请求校验结果是 `action: safe_to_load` 时才加载；如果结果是 `action: ask_user_to_choose`，请先问我要分析哪一篇，不要继续加载。
+```
+
+In `.agents/skills/setting-up-papergraph/references/client-configuration.md`, add `papergraph-mcp validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"` to validation examples if there is a general validation paragraph. If no natural spot exists, do not force it.
+
+- [ ] **Step 5: Run documentation tests and verify they pass**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add README.md .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/usage-prompt.md .agents/skills/setting-up-papergraph/references/client-configuration.md tests/test_repository.py tests/test_onboarding.py
+git commit -m "Recommend high-level arXiv request tools"
+```
+
+---
+
+### Task 6: Full Verification and Handoff
+
+**Files:**
+- Verify: whole repository
+
+**Interfaces:**
+- Consumes: all previous tasks.
+- Produces: branch ready for PR, merge, or keep-as-is decision.
+
+- [ ] **Step 1: Run full test suite**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+```
+
+Expected: PASS with the known skipped test count unless intentionally changed.
+
+- [ ] **Step 2: Run CLI smoke checks**
+
+Run:
+
+```powershell
+.\.venv\Scripts\papergraph-mcp.exe --version
+.\.venv\Scripts\papergraph-mcp.exe validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"
+.\.venv\Scripts\papergraph-mcp.exe load-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"
+```
+
+Expected:
+
+```text
+papergraph-mcp 0.4.4
+```
+
+`validate-arxiv-request` prints JSON with:
+
+```json
+{
+  "status": "conflict",
+  "action": "ask_user_to_choose",
+  "selected_id": null
+}
+```
+
+`load-arxiv-request` prints the same conflict JSON and exits with code `1`.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```powershell
+git status --short
+git diff --stat origin/main...HEAD
+git diff --check
+rg -n "0\\.4\\.3|v0\\.4\\.3" pyproject.toml uv.lock src .github scripts README.md .agents/skills/setting-up-papergraph tests
+```
+
+Expected: no uncommitted changes, no whitespace errors, no active release-surface references to `0.4.3` / `v0.4.3`.
+
+- [ ] **Step 4: Handoff summary**
+
+Prepare:
+
+```markdown
+Summary:
+- Added `validate_arxiv_request` for raw text and Markdown arXiv request validation.
+- Added high-level `load_arxiv_request` that refuses conflicts before loading.
+- Added CLI request commands and updated first-use docs to prefer high-level tools.
+
+Testing:
+- `.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider`
+- `.\.venv\Scripts\papergraph-mcp.exe --version`
+- `.\.venv\Scripts\papergraph-mcp.exe validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"`
+- `.\.venv\Scripts\papergraph-mcp.exe load-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"`
+```
+
+Do not tag or publish `v0.4.4` until the user explicitly approves release.
+
+---
+
+## Self-Review
+
+- Spec coverage: Task 1 handles `0.4.4` / `v0.4.4` release surfaces; Task 2 handles raw text, bare IDs, URLs, Markdown links, match/conflict/invalid statuses, and non-network extraction; Task 3 adds high-level MCP loading and graph preservation on conflict; Task 4 adds CLI request commands including nonzero conflict exit; Task 5 moves README/onboarding defaults to high-level request tools; Task 6 performs full verification and handoff.
+- Placeholder scan: no TBD/TODO/fill-later placeholders remain. Each task gives explicit files, function signatures, tests, commands, expected outputs, and commits.
+- Type consistency: `validate_arxiv_request(input: str) -> dict` and `load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False) -> dict` are introduced before downstream CLI/MCP/docs references.

--- a/docs/superpowers/specs/2026-09-03-v0.4.4-unified-arxiv-request-design.md
+++ b/docs/superpowers/specs/2026-09-03-v0.4.4-unified-arxiv-request-design.md
@@ -1,0 +1,216 @@
+# PaperGraph v0.4.4 Unified arXiv Request Design
+
+## Goal
+
+Make PaperGraph's safest arXiv loading path also the easiest path for agents to
+call. A first-use agent should be able to pass the user's raw arXiv request
+text, including Markdown links, to PaperGraph and let PaperGraph decide whether
+loading is safe.
+
+v0.4.4 builds on v0.4.3. v0.4.3 added explicit validation tools, but agents can
+still bypass them by calling `load_arxiv_paper(arxiv_id=...)` directly. v0.4.4
+adds a higher-level request interface that validates before loading.
+
+## Problem
+
+Recent first-use simulations show two different outcomes:
+
+1. For a clean arXiv ID such as `2609.02842`, the agent used v0.4.3 reasonably:
+   it updated the repository, loaded the paper, reported dependency extraction
+   basis, and described unresolved labels.
+2. For a conflicting Markdown prompt where visible text said `math/0307200` but
+   the link target was `https://arxiv.org/abs/2609.01574`, the agent noticed the
+   mismatch and still loaded `math/0307200`.
+
+The remaining failure is architectural: the safe validator is opt-in. PaperGraph
+needs a default arXiv request entry point that accepts the messy input agents
+actually receive and refuses to load on conflict.
+
+## Success Criteria
+
+- PaperGraph can validate raw request text that contains:
+  - a bare modern ID, such as `2609.02842`;
+  - a bare legacy ID, such as `math/0307200`;
+  - a plain arXiv URL;
+  - a Markdown link whose text and URL agree;
+  - a Markdown link whose text and URL conflict.
+- Conflicting raw request text returns `action: ask_user_to_choose` and no
+  selected ID.
+- A high-level load tool validates raw request text internally before any arXiv
+  download or cache load.
+- The high-level load tool refuses conflicting requests without mutating the
+  active graph.
+- Existing low-level tools remain available for callers that already have a
+  confirmed single arXiv ID.
+- README and onboarding recommend the high-level request tool for first-use
+  prompts and treat `load_arxiv_paper` as a lower-level confirmed-ID tool.
+- Tests cover validation, CLI behavior, MCP behavior, graph-preservation on
+  conflict, and documentation guidance without live arXiv or GitHub access.
+
+## Recommended Design
+
+Add two high-level entry points:
+
+```text
+validate_arxiv_request(input: str) -> dict
+load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False) -> dict
+```
+
+Also expose matching CLI commands:
+
+```powershell
+papergraph-mcp validate-arxiv-request "<raw user text>"
+papergraph-mcp load-arxiv-request "<raw user text>" --main-file main.tex --refresh
+```
+
+The MCP tool `load_arxiv_request` should be the recommended first-use loading
+tool. The CLI load command is useful for smoke tests and manual debugging; it
+should print the same JSON summary as `load_arxiv_paper` on success.
+
+## Input Extraction
+
+`validate_arxiv_request(input)` should extract candidate evidence from raw text:
+
+- Markdown links of the form `[visible text](url)`;
+- bare arXiv IDs in surrounding prose;
+- arXiv URLs in surrounding prose.
+
+The validator should return a dictionary with:
+
+- `input`: original raw request text;
+- `candidates`: ordered evidence records;
+- `normalized_ids`: unique normalized IDs in first-seen order;
+- `status`: `single_input`, `match`, `conflict`, or `invalid`;
+- `action`: `safe_to_load` or `ask_user_to_choose`;
+- `selected_id`: normalized ID only when safe;
+- `message`: concise agent-facing explanation;
+- `errors`: validation or extraction errors.
+
+Candidate evidence records should include:
+
+- `kind`: `markdown_text`, `markdown_url`, `bare_id`, or `plain_url`;
+- `value`: original matched value;
+- `normalized_id`: normalized arXiv ID or `null`;
+- `source`: short source label, such as `markdown` or `text`.
+
+If the same normalized ID appears from multiple evidence sources, the request is
+safe. If more than one normalized ID appears, the request is a conflict.
+
+## Conflict Rule
+
+This is the hard v0.4.4 rule:
+
+```json
+{
+  "status": "conflict",
+  "action": "ask_user_to_choose",
+  "selected_id": null
+}
+```
+
+When `load_arxiv_request` receives that result, it must raise a tool-facing
+error or CLI error before calling `prepare_arxiv_project`. It must not choose
+visible Markdown text over the link target, nor the reverse.
+
+## Loading Flow
+
+`load_arxiv_request` should reuse the existing single-paper load pipeline:
+
+1. Call `validate_arxiv_request(input)`.
+2. If `action` is not `safe_to_load`, stop and return/raise the validator
+   message.
+3. Use `selected_id` with the existing `prepare_arxiv_project`.
+4. Parse the selected source with the existing LaTeX loader and parser.
+5. Replace the active graph only after preparation, loading, parsing, and graph
+   creation succeed.
+6. Return the existing load summary plus request validation metadata.
+
+The old `load_arxiv_paper(arxiv_id, ...)` remains unchanged and remains useful
+for scripted callers that already have a confirmed single ID.
+
+## Error Handling
+
+- Empty input is invalid and asks the user to choose or provide one arXiv input.
+- Non-arXiv URLs are ignored only if another valid arXiv candidate exists; if no
+  valid candidate exists, return invalid.
+- Invalid arXiv-looking tokens should appear in `errors` but should not override
+  a conflict between valid candidates.
+- CLI `load-arxiv-request` should exit nonzero on conflict or invalid input.
+- MCP `load_arxiv_request` should raise `ToolError` on conflict or invalid input.
+
+## Documentation
+
+README and onboarding should change the default first-use instruction:
+
+- Use `validate_arxiv_request` to inspect raw prompts.
+- Use `load_arxiv_request` to load from raw prompts.
+- Use `load_arxiv_paper` only after the intended ID is already confirmed.
+
+The first-use example that currently says
+`load_arxiv_paper(arxiv_id="math/0307200")` should either be replaced by
+`load_arxiv_request(input="math/0307200")` or explicitly labeled as a
+confirmed-ID low-level call.
+
+The onboarding skill should say that an agent has failed if it notices a
+Markdown ID/URL conflict and then calls `load_arxiv_paper` anyway.
+
+## Compatibility
+
+- Do not remove or change `validate_arxiv_input`.
+- Do not remove or change `load_arxiv_paper`.
+- Do not change single-paper graph state unless high-level request loading
+  succeeds.
+- Do not introduce network-dependent tests.
+- Do not infer main theorem status or semantic theorem dependencies in this
+  release.
+
+## Testing
+
+Add tests for:
+
+- raw bare modern ID validation;
+- raw bare legacy ID validation;
+- raw plain arXiv URL validation;
+- matching Markdown visible text and URL;
+- conflicting Markdown visible text and URL;
+- prose containing both a bare ID and a conflicting URL;
+- invalid raw input;
+- `load_arxiv_request` success through a monkeypatched arXiv project;
+- `load_arxiv_request` conflict preserving any previously active graph;
+- CLI `validate-arxiv-request`;
+- CLI `load-arxiv-request` conflict exit;
+- MCP `validate_arxiv_request`;
+- MCP `load_arxiv_request`;
+- README and onboarding recommending high-level request tools.
+
+Full verification remains:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+```
+
+After merge and release, the public smoke tests are:
+
+```powershell
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4 papergraph-mcp validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"
+```
+
+## Release Boundaries
+
+The target release is `0.4.4` / `v0.4.4`.
+
+Do not create tags, publish releases, merge PRs, delete branches, clean up
+worktrees, or modify the separate `D:\August\papergraph-mcp` clone without
+explicit user approval.
+
+## Future Direction
+
+After v0.4.4, the next substantive line can move from entry reliability to
+mathematical quality:
+
+- proof-aware dependency extraction;
+- main theorem candidate ranking with explicit uncertainty;
+- stronger real-paper regression fixtures;
+- structured result templates that make underpowered dependency evidence hard
+  to overstate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.4.3"
+PAPERGRAPH_VERSION = "0.4.4"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.4.3"
+    "papergraph-mcp.git@v0.4.4"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -31,6 +31,14 @@ _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"
 )
+_ARXIV_ID_SEARCH_RE = re.compile(
+    r"(?<![A-Za-z0-9./:-])(?:arXiv:)?"
+    r"(\d{4}\.\d{4,5}(?:v[1-9]\d*)?|[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?)"
+    r"(?![A-Za-z0-9./-])",
+    re.IGNORECASE,
+)
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+_URL_RE = re.compile(r"https?://[^\s<>)\]]+")
 _ARXIV_URL_HOSTS = {"arxiv.org", "www.arxiv.org", "export.arxiv.org"}
 _ARXIV_URL_PREFIXES = {"/abs/", "/pdf/"}
 _HTTP_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=60.0, pool=10.0)
@@ -194,6 +202,135 @@ def validate_arxiv_input(
         "action": "safe_to_load",
         "selected_id": selected_id,
         "message": f"One arXiv input was provided. It is safe to load {selected_id}.",
+        "errors": [],
+    }
+
+
+def _candidate(kind: str, raw: str, normalized_id: str) -> dict:
+    return {
+        "kind": kind,
+        "raw": raw,
+        "normalized_id": normalized_id,
+    }
+
+
+def _span_is_consumed(span: tuple[int, int], consumed_spans: list[tuple[int, int]]) -> bool:
+    start, end = span
+    return any(start >= used_start and end <= used_end for used_start, used_end in consumed_spans)
+
+
+def _append_unique_normalized_id(normalized_ids: list[str], normalized_id: str) -> None:
+    if normalized_id not in normalized_ids:
+        normalized_ids.append(normalized_id)
+
+
+def _extract_request_candidates(value: str) -> list[dict]:
+    candidates: list[dict] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    for match in _MARKDOWN_LINK_RE.finditer(value):
+        consumed_spans.append(match.span())
+        text, url = match.groups()
+        try:
+            candidates.append(
+                _candidate("markdown_text", text, normalize_arxiv_id(text))
+            )
+        except InvalidArxivIdError:
+            pass
+        try:
+            candidates.append(
+                _candidate("markdown_url", url, extract_arxiv_id_from_url(url))
+            )
+        except InvalidArxivIdError:
+            pass
+
+    for match in _URL_RE.finditer(value):
+        if _span_is_consumed(match.span(), consumed_spans):
+            continue
+        consumed_spans.append(match.span())
+        url = match.group(0)
+        try:
+            candidates.append(
+                _candidate("plain_url", url, extract_arxiv_id_from_url(url))
+            )
+        except InvalidArxivIdError:
+            pass
+
+    for match in _ARXIV_ID_SEARCH_RE.finditer(value):
+        if _span_is_consumed(match.span(), consumed_spans):
+            continue
+        raw = match.group(0)
+        try:
+            candidates.append(_candidate("bare_id", raw, normalize_arxiv_id(raw)))
+        except InvalidArxivIdError:
+            pass
+
+    return candidates
+
+
+def validate_arxiv_request(input: str) -> dict:
+    """Extract arXiv IDs from a raw user request and return the safe next action."""
+
+    if not isinstance(input, str):
+        return {
+            "input": input,
+            "candidates": [],
+            "normalized_ids": [],
+            "status": "invalid",
+            "action": "ask_user_to_choose",
+            "selected_id": None,
+            "message": (
+                "The arXiv request must be text. Ask the user for one supported "
+                "arXiv ID, URL, or Markdown link before loading a paper."
+            ),
+            "errors": ["arXiv request must be text."],
+        }
+
+    candidates = _extract_request_candidates(input)
+    normalized_ids: list[str] = []
+    for item in candidates:
+        _append_unique_normalized_id(normalized_ids, item["normalized_id"])
+
+    if not normalized_ids:
+        return {
+            "input": input,
+            "candidates": candidates,
+            "normalized_ids": normalized_ids,
+            "status": "invalid",
+            "action": "ask_user_to_choose",
+            "selected_id": None,
+            "message": (
+                "No supported arXiv ID or arXiv URL was found. Ask the user for "
+                "one supported arXiv ID, URL, or Markdown arXiv link."
+            ),
+            "errors": ["Provide one arXiv ID, arXiv URL, or Markdown arXiv link."],
+        }
+
+    if len(normalized_ids) > 1:
+        return {
+            "input": input,
+            "candidates": candidates,
+            "normalized_ids": normalized_ids,
+            "status": "conflict",
+            "action": "ask_user_to_choose",
+            "selected_id": None,
+            "message": (
+                "The request contains multiple different arXiv IDs. Ask the user "
+                "which paper to analyze before loading anything."
+            ),
+            "errors": [],
+        }
+
+    selected_id = normalized_ids[0]
+    status = "match" if len(candidates) > 1 else "single_input"
+    return {
+        "input": input,
+        "candidates": candidates,
+        "normalized_ids": normalized_ids,
+        "status": status,
+        "action": "safe_to_load",
+        "selected_id": selected_id,
+        "message": f"The request identifies one paper. It is safe to load {selected_id}.",
         "errors": [],
     }
 

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -26,7 +26,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.4.3 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.4.4 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -12,8 +12,10 @@ from mcp.server.mcpserver.exceptions import ToolError
 
 from papergraph.arxiv import (
     ArxivImportError,
+    ArxivProject,
     prepare_arxiv_project,
     validate_arxiv_input as validate_arxiv_input_result,
+    validate_arxiv_request as validate_arxiv_request_result,
 )
 from papergraph.diagnostics import environment_diagnostics
 from papergraph.graph import PaperGraph
@@ -103,6 +105,13 @@ def validate_arxiv_input(
     """Normalize arXiv ID and URL inputs and return the safe next action."""
 
     return validate_arxiv_input_result(text_id=text_id, url=url)
+
+
+@mcp.tool()
+def validate_arxiv_request(input: str) -> dict:
+    """Validate a raw user arXiv request and return the safe next action."""
+
+    return validate_arxiv_request_result(input)
 
 
 @mcp.tool()
@@ -320,25 +329,13 @@ def load_paper(path: str) -> dict:
     }
 
 
-@mcp.tool()
-def load_arxiv_paper(
-    arxiv_id: str,
-    main_file: str | None = None,
-    refresh: bool = False,
-) -> dict:
-    """Download an arXiv source project and build its theorem graph."""
-
+def _load_prepared_arxiv_project(project: ArxivProject) -> dict:
     global _current_graph
     global _current_path
 
     try:
-        project = prepare_arxiv_project(
-            arxiv_id,
-            main_file,
-            refresh,
-        )
         text = load_latex_project(project.main_file)
-    except (ArxivImportError, OSError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
         raise ToolError(str(exc)) from exc
 
     nodes = parse_latex(text)
@@ -358,6 +355,52 @@ def load_arxiv_paper(
         "nodes": len(nodes),
         "kinds": kinds,
     }
+
+
+@mcp.tool()
+def load_arxiv_paper(
+    arxiv_id: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+) -> dict:
+    """Download an arXiv source project and build its theorem graph."""
+
+    try:
+        project = prepare_arxiv_project(
+            arxiv_id,
+            main_file,
+            refresh,
+        )
+    except ArxivImportError as exc:
+        raise ToolError(str(exc)) from exc
+
+    return _load_prepared_arxiv_project(project)
+
+
+@mcp.tool()
+def load_arxiv_request(
+    input: str,
+    main_file: str | None = None,
+    refresh: bool = False,
+) -> dict:
+    """Validate a raw arXiv request, then load it only if unambiguous."""
+
+    validation = validate_arxiv_request_result(input)
+    if validation["action"] != "safe_to_load" or validation["selected_id"] is None:
+        raise ToolError(validation["message"])
+
+    try:
+        project = prepare_arxiv_project(
+            validation["selected_id"],
+            main_file,
+            refresh,
+        )
+    except ArxivImportError as exc:
+        raise ToolError(str(exc)) from exc
+
+    result = _load_prepared_arxiv_project(project)
+    result["validation"] = validation
+    return result
 
 
 @mcp.tool()

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -529,6 +529,18 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
     validate_parser.add_argument("--id", dest="text_id")
     validate_parser.add_argument("--url")
+    validate_request_parser = subparsers.add_parser(
+        "validate-arxiv-request",
+        help="Validate a raw arXiv request before loading a paper.",
+    )
+    validate_request_parser.add_argument("input")
+    load_request_parser = subparsers.add_parser(
+        "load-arxiv-request",
+        help="Validate and load a raw arXiv request as JSON.",
+    )
+    load_request_parser.add_argument("input")
+    load_request_parser.add_argument("--main-file")
+    load_request_parser.add_argument("--refresh", action="store_true")
 
     args = parser.parse_args(argv)
     if args.command == "doctor":
@@ -541,6 +553,34 @@ def main(argv: Sequence[str] | None = None) -> None:
                 url=args.url,
             )
         )
+        return
+    if args.command == "validate-arxiv-request":
+        _print_json(validate_arxiv_request_result(args.input))
+        return
+    if args.command == "load-arxiv-request":
+        validation = validate_arxiv_request_result(args.input)
+        if validation["action"] != "safe_to_load" or validation["selected_id"] is None:
+            _print_json(validation)
+            raise SystemExit(1)
+        try:
+            _print_json(
+                load_arxiv_request(
+                    args.input,
+                    main_file=args.main_file,
+                    refresh=args.refresh,
+                )
+            )
+        except ToolError as exc:
+            _print_json(
+                {
+                    "status": "error",
+                    "action": "inspect_error",
+                    "selected_id": validation["selected_id"],
+                    "message": str(exc),
+                    "validation": validation,
+                }
+            )
+            raise SystemExit(1) from exc
         return
     mcp.run()
 

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -18,6 +18,7 @@ from papergraph.arxiv import (
     prepare_arxiv_project,
     select_main_file,
     validate_arxiv_input,
+    validate_arxiv_request,
 )
 
 
@@ -147,6 +148,81 @@ def test_validate_arxiv_input_reports_invalid_inputs_without_selection():
     assert result["normalized_text_id"] is None
     assert result["normalized_url_id"] is None
     assert len(result["errors"]) == 2
+
+
+@pytest.mark.parametrize(
+    ("raw_request", "selected_id", "status"),
+    [
+        ("2609.02842", "2609.02842", "single_input"),
+        ("Please load math/0307200", "math/0307200", "single_input"),
+        ("https://arxiv.org/abs/2609.01574", "2609.01574", "single_input"),
+        ("[math/0307200](https://arxiv.org/abs/math/0307200)", "math/0307200", "match"),
+    ],
+)
+def test_validate_arxiv_request_accepts_single_or_matching_requests(
+    raw_request: str,
+    selected_id: str,
+    status: str,
+):
+    result = validate_arxiv_request(raw_request)
+
+    assert result["input"] == raw_request
+    assert result["status"] == status
+    assert result["action"] == "safe_to_load"
+    assert result["selected_id"] == selected_id
+    assert result["normalized_ids"] == [selected_id]
+    assert result["errors"] == []
+
+
+def test_validate_arxiv_request_stops_on_markdown_text_url_conflict():
+    request = "[math/0307200](https://arxiv.org/abs/2609.01574)"
+
+    result = validate_arxiv_request(request)
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_ids"] == ["math/0307200", "2609.01574"]
+    assert [candidate["kind"] for candidate in result["candidates"]] == [
+        "markdown_text",
+        "markdown_url",
+    ]
+    assert "ask the user" in result["message"].lower()
+    assert result["errors"] == []
+
+
+def test_validate_arxiv_request_stops_on_prose_text_url_conflict():
+    result = validate_arxiv_request(
+        "Load math/0307200 from https://arxiv.org/abs/2609.01574"
+    )
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_ids"] == ["2609.01574", "math/0307200"]
+
+
+def test_validate_arxiv_request_reports_empty_input_as_invalid():
+    result = validate_arxiv_request("   ")
+
+    assert result["status"] == "invalid"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_ids"] == []
+    assert result["candidates"] == []
+    assert result["errors"] == ["Provide one arXiv ID, arXiv URL, or Markdown arXiv link."]
+
+
+def test_validate_arxiv_request_ignores_non_arxiv_url_when_id_is_present():
+    result = validate_arxiv_request(
+        "Please load 2609.02842, source page https://example.com/2609.01574"
+    )
+
+    assert result["status"] == "single_input"
+    assert result["action"] == "safe_to_load"
+    assert result["selected_id"] == "2609.02842"
+    assert result["normalized_ids"] == ["2609.02842"]
+    assert result["errors"] == []
 
 
 def test_download_uses_fixed_endpoint_headers_redirects_and_streaming(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,3 +111,84 @@ def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(
     assert payload["status"] == "conflict"
     assert payload["action"] == "ask_user_to_choose"
     assert payload["selected_id"] is None
+
+
+def test_validate_arxiv_request_cli_prints_conflict_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+
+    server.main(
+        [
+            "validate-arxiv-request",
+            "[math/0307200](https://arxiv.org/abs/2609.01574)",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "conflict"
+    assert payload["action"] == "ask_user_to_choose"
+    assert payload["selected_id"] is None
+    assert payload["normalized_ids"] == ["math/0307200", "2609.01574"]
+
+
+def test_load_arxiv_request_cli_stops_on_conflict_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+
+    with pytest.raises(SystemExit) as caught:
+        server.main(
+            [
+                "load-arxiv-request",
+                "[math/0307200](https://arxiv.org/abs/2609.01574)",
+            ]
+        )
+
+    assert caught.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "conflict"
+    assert payload["action"] == "ask_user_to_choose"
+    assert payload["selected_id"] is None
+
+
+def test_load_arxiv_request_cli_prints_loaded_json_without_starting_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setattr(server.mcp, "run", fail_if_mcp_runs)
+
+    def load(input: str, main_file: str | None = None, refresh: bool = False) -> dict:
+        return {
+            "arxiv_id": "2609.02842",
+            "path": "paper.tex",
+            "cached": False,
+            "nodes": 1,
+            "kinds": {"theorem": 1},
+            "main_file": main_file,
+            "refresh": refresh,
+            "validation": {
+                "status": "single_input",
+                "selected_id": "2609.02842",
+            },
+        }
+
+    monkeypatch.setattr(server, "load_arxiv_request", load)
+
+    server.main(
+        [
+            "load-arxiv-request",
+            "https://arxiv.org/abs/2609.02842",
+            "--main-file",
+            "paper.tex",
+            "--refresh",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["arxiv_id"] == "2609.02842"
+    assert payload["main_file"] == "paper.tex"
+    assert payload["refresh"] is True
+    assert payload["validation"]["selected_id"] == "2609.02842"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.4.3\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.4.4\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(
@@ -74,11 +74,11 @@ def test_doctor_prints_json_without_starting_mcp(
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.4.3",
-            "release_tag": "v0.4.3",
+            "version": "0.4.4",
+            "release_tag": "v0.4.4",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.4.3"
+                "papergraph-mcp.git@v0.4.4"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -88,7 +88,7 @@ def test_doctor_prints_json_without_starting_mcp(
 
     server.main(["doctor"])
 
-    assert json.loads(capsys.readouterr().out)["version"] == "0.4.3"
+    assert json.loads(capsys.readouterr().out)["version"] == "0.4.4"
 
 
 def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,11 +5,11 @@ def test_environment_diagnostics_reports_version_and_release_source():
     result = environment_diagnostics()
 
     assert result["package_name"] == "papergraph-mcp"
-    assert result["version"] == "0.4.3"
-    assert result["release_tag"] == "v0.4.3"
+    assert result["version"] == "0.4.4"
+    assert result["release_tag"] == "v0.4.4"
     assert (
         result["recommended_source"]
-        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3"
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4"
     )
     assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
     assert isinstance(result["warnings"], list)
@@ -25,6 +25,6 @@ def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
 
     result = environment_diagnostics()
 
-    assert result["version"] == "0.4.3"
+    assert result["version"] == "0.4.4"
     assert result["git"] is None
     assert any("Git context unavailable" in warning for warning in result["warnings"])

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -332,11 +332,13 @@ def test_onboarding_requires_refresh_diagnostics_and_conflict_stop():
 
     assert "git fetch --tags origin" in skill
     assert "papergraph-mcp doctor" in skill
-    assert "validate_arxiv_input" in skill
-    assert "Call `load_arxiv_paper` only when" in skill
+    assert "validate_arxiv_request" in skill
+    assert "load_arxiv_request" in skill
+    assert "Use `load_arxiv_paper` only after" in skill
     assert "detecting a conflict and then continuing is a failure" in skill
     assert "get_environment_diagnostics" in prompt
-    assert "validate_arxiv_input" in prompt
+    assert "validate_arxiv_request" in prompt
+    assert "load_arxiv_request" in prompt
     assert "ask_user_to_choose" in prompt
     assert "papergraph-mcp doctor" in client_reference
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.3"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.4.4"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.4.3\n"
+        stdout = "papergraph-mcp 0.4.4\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.4.3"
+    assert result["version"] == "papergraph-mcp 0.4.4"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.3"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.4.4"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -348,7 +348,7 @@ def test_readme_exposes_agent_guided_setup():
     assert ".agents/skills/setting-up-papergraph/SKILL.md" in text
 
 
-def test_all_onboarding_source_pins_match_v043():
+def test_all_onboarding_source_pins_match_v044():
     import re
 
     combined = "\n".join(
@@ -359,4 +359,4 @@ def test_all_onboarding_source_pins_match_v043():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.4.3"}
+    assert set(refs) == {"v0.4.4"}

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -270,13 +270,14 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     assert "raw_kind" in readme
     assert "display_kind" in readme
     assert "normalized_kind" in readme
-    assert "If a prompt contains both an arXiv ID and an arXiv URL" in readme
+    assert "For raw user requests, prefer" in readme
     assert "papergraph-mcp doctor" in readme
-    assert "validate-arxiv" in readme
+    assert "validate-arxiv-request" in readme
     assert "`get_environment_diagnostics`" in readme
-    assert "`validate_arxiv_input`" in readme
+    assert "`validate_arxiv_request`" in readme
+    assert "`load_arxiv_request`" in readme
     assert "git fetch --tags origin" in readme
-    assert "Call `load_arxiv_paper` only when" in readme
+    assert "Use `load_arxiv_paper` only after" in readme
     assert "detecting a conflict and then continuing is a failure" in readme
 
     assert 'arxiv_id="math/0307200"' in readme
@@ -318,7 +319,8 @@ def test_onboarding_uses_v044_release_pin_and_mentions_id_url_conflicts():
 
     assert "papergraph-mcp.git@v0.4.4" in skill
     assert "papergraph-mcp 0.4.4" in skill
-    assert "validate_arxiv_input" in skill
+    assert "validate_arxiv_request" in skill
+    assert "load_arxiv_request" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill
     assert "ask which one to analyze" in skill
     assert "arXiv ID and arXiv URL" in prompt

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -21,7 +21,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.4.3"
+    assert project["version"] == "0.4.4"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -65,7 +65,7 @@ def test_lockfile_matches_project_version():
         if package["name"] == "papergraph-mcp"
     )
 
-    assert package["version"] == "0.4.3"
+    assert package["version"] == "0.4.4"
 
 
 def test_runtime_and_issue_template_release_strings_match_project_version():
@@ -120,7 +120,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.4.3" in build_steps
+    assert "papergraph-mcp 0.4.4" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -228,7 +228,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.4.3"
+        "papergraph-mcp.git@v0.4.4"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):
@@ -239,7 +239,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     )
     assert '"command": "uvx"' in readme
     assert pinned_source in readme
-    assert "PaperGraph v0.4.3" in readme
+    assert "PaperGraph v0.4.4" in readme
 
     for tool_name in (
         "load_paper",
@@ -308,7 +308,7 @@ def test_readme_documents_v040_cross_paper_graph_history():
     assert "semantic" in readme.lower()
 
 
-def test_onboarding_uses_v043_release_pin_and_mentions_id_url_conflicts():
+def test_onboarding_uses_v044_release_pin_and_mentions_id_url_conflicts():
     skill = (
         ROOT / ".agents/skills/setting-up-papergraph/SKILL.md"
     ).read_text(encoding="utf-8")
@@ -316,8 +316,8 @@ def test_onboarding_uses_v043_release_pin_and_mentions_id_url_conflicts():
         ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
     ).read_text(encoding="utf-8")
 
-    assert "papergraph-mcp.git@v0.4.3" in skill
-    assert "papergraph-mcp 0.4.3" in skill
+    assert "papergraph-mcp.git@v0.4.4" in skill
+    assert "papergraph-mcp 0.4.4" in skill
     assert "validate_arxiv_input" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill
     assert "ask which one to analyze" in skill

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -195,6 +195,62 @@ def test_validate_arxiv_input_tool_reports_conflict():
     assert result["selected_id"] is None
 
 
+def test_validate_arxiv_request_tool_reports_markdown_conflict():
+    result = server.validate_arxiv_request(
+        "[math/0307200](https://arxiv.org/abs/2609.01574)"
+    )
+
+    assert result["status"] == "conflict"
+    assert result["action"] == "ask_user_to_choose"
+    assert result["selected_id"] is None
+    assert result["normalized_ids"] == ["math/0307200", "2609.01574"]
+
+
+def test_load_arxiv_request_loads_valid_request_and_includes_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    project = make_multifile_project(tmp_path)
+    monkeypatch.setattr(server, "prepare_arxiv_project", lambda *args, **kwargs: project)
+
+    result = server.load_arxiv_request("Please load arXiv:2401.12345")
+
+    assert result["arxiv_id"] == "2401.12345"
+    assert result["nodes"] == 2
+    assert result["validation"]["status"] == "single_input"
+    assert result["validation"]["selected_id"] == "2401.12345"
+    assert [node["id"] for node in server.list_theorems()] == [
+        "lem:base",
+        "thm:result",
+    ]
+
+
+def test_load_arxiv_request_conflict_preserves_active_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    local = tmp_path / "local.tex"
+    local.write_text(
+        "\\newtheorem{lemma}{Lemma}\n"
+        "\\begin{lemma}Local.\\label{lem:local}\\end{lemma}",
+        encoding="utf-8",
+    )
+    server.load_paper(str(local))
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("conflicting raw requests must not prepare a project")
+
+    monkeypatch.setattr(server, "prepare_arxiv_project", fail_if_called)
+
+    with pytest.raises(ToolError, match="multiple different arXiv IDs"):
+        server.load_arxiv_request(
+            "[math/0307200](https://arxiv.org/abs/2609.01574)"
+        )
+
+    assert [node["id"] for node in server.list_theorems()] == ["lem:local"]
+    assert server._current_path == local.resolve()
+
+
 def test_get_dependency_diagnostics_reports_single_paper_basis(tmp_path: Path):
     local = tmp_path / "local.tex"
     local.write_text(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,11 +169,11 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.4.3",
-            "release_tag": "v0.4.3",
+            "version": "0.4.4",
+            "release_tag": "v0.4.4",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.4.3"
+                "papergraph-mcp.git@v0.4.4"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -181,7 +181,7 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         },
     )
 
-    assert server.get_environment_diagnostics()["release_tag"] == "v0.4.3"
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.4.4"
 
 
 def test_validate_arxiv_input_tool_reports_conflict():

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Bump PaperGraph release surfaces to v0.4.4.
- Add `validate_arxiv_request(input)` to parse raw user text, Markdown links, bare arXiv IDs, and arXiv URLs with conflict detection.
- Add `load_arxiv_request(input, main_file=None, refresh=False)` for MCP and CLI so ambiguous first-use prompts stop before downloading or replacing the active graph.
- Update onboarding docs and the reusable setup prompt to prefer the high-level request tools.

## Verification

- `python -m pytest -q -p no:cacheprovider` -> 294 passed, 1 skipped
- `papergraph-mcp --version` -> `papergraph-mcp 0.4.4`
- `papergraph-mcp validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"` -> `status: conflict`, `action: ask_user_to_choose`
- `papergraph-mcp load-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"` -> exits 1 with the same conflict JSON