### PR TITLE
Add Reading Queue Planner for v0.8.0

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -47,23 +47,23 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.7.0`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.8.0`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version
 ```
 
 The expected output is:
 
 ```text
-papergraph-mcp 0.7.0
+papergraph-mcp 0.8.0
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.7.0"
+      placeholder: "0.8.0"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.7.0"
+          test "$version" = "papergraph-mcp 0.8.0"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/lotchuazzz-crypto/papergraph-mcp)](https://github.com/lotchuazzz-crypto/papergraph-mcp/releases)
 
-PaperGraph turns local or arXiv LaTeX papers and born-digital PDFs into evidence-first theorem, result, proof, and reading-session state that AI agents can query through MCP. PaperGraph v0.7.0 adds persistent Reading Session State so agents can resume which evidence targets were reviewed, blocked, queued, or left as open questions.
+PaperGraph turns local or arXiv LaTeX papers and born-digital PDFs into evidence-first theorem, result, proof, reading-session, and reading-queue state that AI agents can query through MCP. PaperGraph v0.8.0 adds a persistent Reading Queue Planner so agents can turn local proof-dependency paths into required, recommended, and caution reading targets, then apply those targets to resumable reading sessions.
+
+PaperGraph v0.7.0 added persistent Reading Session State so agents can resume which evidence targets were reviewed, blocked, queued, or left as open questions.
 
 PaperGraph v0.6.1 added command-line Reading Bridge exports so terminal workflows and CI scripts can inspect bridge payloads from an existing workspace without starting MCP.
 
@@ -25,6 +27,7 @@ Single-paper tools expose theorem-like environments, labels, and `\ref` relation
 - Import born-digital PDFs into the same local workspace and inspect extracted result and proof evidence.
 - Export reading bridge bundles, result contexts, source slices, and reading paths for explanation-focused consumers.
 - Persist reading sessions, checkpoints, notes, open questions, and recovery summaries in the local workspace.
+- Plan deterministic reading queues from proof-dependency evidence and apply them to reading sessions.
 - Keep theorem, reference, and citation records in a local SQLite workspace.
 - Search theorem titles and bodies across papers, with stable global IDs.
 - Traverse direct or recursive theorem dependencies and inspect incoming or outgoing citation evidence, including unresolved citations.
@@ -58,11 +61,11 @@ the decision without loading, call `validate_arxiv_request` or
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the GitHub release without cloning the repository:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
-The pinned command becomes available after the `v0.7.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.8.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 To validate a raw arXiv request before loading a paper, run:
 
@@ -79,7 +82,7 @@ For an MCP client that accepts JSON-style stdio server configuration, add:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0", "papergraph-mcp"]
     }
   }
 }
@@ -91,7 +94,7 @@ Restart the MCP client after changing its configuration. The server uses stdio, 
 
 The original single-paper tools remain available: `get_environment_diagnostics`, `validate_arxiv_request`, `load_arxiv_request`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`. Their signatures are `get_environment_diagnostics()`, `validate_arxiv_request(input: str)`, `load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False)`, `validate_arxiv_input(text_id: str | None = None, url: str | None = None)`, `load_paper(path: str)`, `load_arxiv_paper(arxiv_id: str, main_file: str | None = None, refresh: bool = False)`, `list_theorems(kind: str | None = None)`, `get_theorem(theorem_id: str)`, `get_dependencies(theorem_id: str, recursive: bool = False)`, `get_dependency_diagnostics(theorem_id: str, recursive: bool = False)`, and `where_used(theorem_id: str)`.
 
-Workspace tools operate on the active database. Call `open_workspace` first: `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_add_pdf_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, and `workspace_export_reading_session_summary` require that active workspace. Their exact MCP signatures and return summaries are:
+Workspace tools operate on the active database. Call `open_workspace` first: `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_add_pdf_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary`, `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, and `workspace_apply_reading_queue_to_session` require that active workspace. Their exact MCP signatures and return summaries are:
 
 | Tool signature | Returns |
 | --- | --- |
@@ -122,6 +125,10 @@ Workspace tools operate on the active database. Call `open_workspace` first: `wo
 | `workspace_record_reading_checkpoint(session_id: str, target_kind: str, target_id: str, status: str, summary: str = "", evidence: dict | None = None) -> dict` | Creates or updates a reviewed, blocked, queued, or skipped reading checkpoint for one explicit target. |
 | `workspace_add_reading_note(session_id: str, text: str, note_type: str = "note", target_kind: str | None = None, target_id: str | None = None) -> dict` | Adds a note, question, warning, or decision to a session and optional target. |
 | `workspace_export_reading_session_summary(session_id: str) -> dict` | Exports recovery progress, reviewed targets, blocked targets, open questions, latest notes, and deterministic next-action hints. |
+| `workspace_create_reading_queue(result_id: str, label: str | None = None, recursive: bool = True) -> dict` | Creates a persistent reading queue from a result's local reading path, proof evidence, external stops, and unresolved stops. |
+| `workspace_list_reading_queues(paper_id: str | None = None, status: str | None = None) -> list[dict]` | Lists queues ordered for resumption, optionally filtered by paper or active/archived status. |
+| `workspace_get_reading_queue(queue_id: str) -> dict` | Returns one queue with deterministic required, recommended, and caution item ordering. |
+| `workspace_apply_reading_queue_to_session(queue_id: str, session_id: str, status: str = "queued") -> dict` | Applies queue items as reading-session checkpoints with queue provenance. |
 
 For a compact single-paper check with an already-disambiguated ID, call `load_arxiv_paper(arxiv_id="math/0307200")`. For ordinary user text, call `load_arxiv_request(input="math/0307200")`. PaperGraph selects `main.tex`; a representative first response has `"path": "main.tex"`, `"cached": false`, and `"nodes": 7`.
 
@@ -201,6 +208,30 @@ papergraph-mcp export-reading-session-summary --workspace C:/Temp/papergraph-rea
 ```
 
 Session summaries include progress counts, reviewed targets, blocked targets, open questions, latest notes, and deterministic next-action hints such as `review_blocked_targets` or `continue_queued_targets`. The hints are reading-state cues, not mathematical advice.
+
+## Reading queue workflow
+
+Use the Reading Queue Planner when a paper-reading agent should start from a selected result and receive an explicit, ordered set of reading targets. Queue items are deterministic: the selected result and its proof are `required`, local proof dependencies and their proofs are `recommended`, and external or unresolved stops are `caution`.
+
+```text
+open_workspace(path="C:/Temp/papergraph-reading.sqlite3")
+workspace_create_reading_queue(result_id="local:example::pdf:theorem:1.1", label="Main theorem queue")
+workspace_get_reading_queue(queue_id="queue:...")
+workspace_create_reading_session(paper_id="local:example", label="Main theorem pass", target_result_id="local:example::pdf:theorem:1.1")
+workspace_apply_reading_queue_to_session(queue_id="queue:...", session_id="session:...")
+workspace_export_reading_session_summary(session_id="session:...")
+```
+
+The same queue workflow can be used from a shell against an existing workspace:
+
+```powershell
+papergraph-mcp create-reading-queue --workspace C:/Temp/papergraph-reading.sqlite3 --result-id local:example::pdf:theorem:1.1 --label "Main theorem queue"
+papergraph-mcp list-reading-queues --workspace C:/Temp/papergraph-reading.sqlite3 --paper-id local:example
+papergraph-mcp get-reading-queue --workspace C:/Temp/papergraph-reading.sqlite3 --queue-id queue:...
+papergraph-mcp apply-reading-queue-to-session --workspace C:/Temp/papergraph-reading.sqlite3 --queue-id queue:... --session-id session:...
+```
+
+Reading queues do not verify proofs or generate theorem explanations. They preserve the evidence-derived order and stop reasons so a reading agent can inspect, explain, or defer each target without silently inventing missing dependencies.
 
 ## Three-paper local walkthrough
 

--- a/docs/superpowers/plans/2026-09-07-reading-queue-planner-v0.8.md
+++ b/docs/superpowers/plans/2026-09-07-reading-queue-planner-v0.8.md
@@ -1,0 +1,343 @@
+# Reading Queue Planner v0.8 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent Reading Queue Planner support that converts existing result reading-path evidence into ordered queue items and can apply those items to v0.7 reading sessions.
+
+**Architecture:** Advance the SQLite workspace schema to v5 with `reading_queues` and `reading_queue_items`. Build queue items inside `Workspace` from existing `get_result_reading_path`, `get_result_proof`, and `record_reading_checkpoint` APIs, then expose the same behavior through MCP wrappers and JSON CLI commands.
+
+**Tech Stack:** Python 3.10+, SQLite, pytest, existing PaperGraph MCP server and argparse CLI.
+
+## Global Constraints
+
+- The workspace schema advances from version 4 to version 5.
+- Queue statuses are exactly `active` and `archived`.
+- Queue item target kinds are exactly `result_id`, `proof_id`, `span_id`, `external_stop`, and `unresolved_stop`.
+- Queue item priorities are exactly `required`, `recommended`, and `caution`.
+- Applying a queue to a session may only use checkpoint statuses `queued`, `reviewed`, `blocked`, or `skipped`; default is `queued`.
+- The planner must not generate mathematical explanations, verify proofs, perform semantic ranking, or automatically import citations.
+- The active release version becomes `0.8.0` and release pins become `v0.8.0`.
+
+---
+
+## File Structure
+
+- `src/papergraph/workspace.py`: schema v5 migration, queue persistence, queue planner, queue-to-session application.
+- `src/papergraph/server.py`: MCP wrappers and CLI commands.
+- `tests/test_workspace_reading_queue.py`: workspace-level schema, planner, listing, retrieval, and apply tests.
+- `tests/test_workspace_reading_queue_server.py`: MCP wrapper success and error conversion tests.
+- `tests/test_cli_reading_queue.py`: JSON CLI round-trip tests.
+- `tests/test_workspace.py`, `tests/test_workspace_evidence.py`, `tests/test_workspace_server.py`: schema-version expectation updates.
+- `tests/test_repository.py`, `tests/test_onboarding.py`: repository metadata and version pin expectation updates.
+- `README.md`, `pyproject.toml`, `uv.lock`, `.github/workflows/ci.yml`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `scripts/check_onboarding.py`, `src/papergraph/arxiv.py`, `.agents/skills/setting-up-papergraph/SKILL.md`, `.agents/skills/setting-up-papergraph/references/client-configuration.md`: v0.8.0 release surface updates.
+
+---
+
+### Task 1: Workspace Queue Schema And Planner
+
+**Files:**
+- Modify: `src/papergraph/workspace.py`
+- Create: `tests/test_workspace_reading_queue.py`
+- Modify: `tests/test_workspace.py`
+- Modify: `tests/test_workspace_evidence.py`
+- Modify: `tests/test_workspace_server.py`
+
+**Interfaces:**
+- Consumes: `Workspace.get_result_reading_path(result_id: str, recursive: bool = True) -> dict`, `Workspace.get_result_proof(result_id: str) -> dict`, `Workspace.record_reading_checkpoint(...) -> dict`
+- Produces: `Workspace.create_reading_queue(result_id: str, label: str | None = None, recursive: bool = True) -> dict`, `Workspace.list_reading_queues(paper_id: str | None = None, status: str | None = None) -> list[dict]`, `Workspace.get_reading_queue(queue_id: str) -> dict`, `Workspace.apply_reading_queue_to_session(queue_id: str, session_id: str, status: str = "queued") -> dict`
+
+- [ ] **Step 1: Write failing workspace tests**
+
+Create `tests/test_workspace_reading_queue.py` with tests that build small PDF workspaces, assert schema v5 queue tables exist, migrate a v4 database by dropping future tables and setting schema `4`, create a queue for a result, verify deterministic item order and duplicate suppression, list/get queues, apply a queue to a reading session, and reject cross-paper application.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_workspace_reading_queue.py -v
+```
+
+Expected: fail because `Workspace` has no reading queue methods and schema v5 tables are missing.
+
+- [ ] **Step 3: Implement schema v5 and workspace queue methods**
+
+In `src/papergraph/workspace.py`, set `SCHEMA_VERSION = 5`, add queue constants, extend `_REQUIRED_TABLES` and `_REQUIRED_TABLE_COLUMNS`, add `_READING_QUEUE_SCHEMA_SQL`, add `_migrate_v4_to_v5`, call it from `_ensure_schema`, and implement the public queue methods plus private payload/id/item helpers.
+
+- [ ] **Step 4: Run workspace queue tests to verify GREEN**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_workspace_reading_queue.py -v
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Update existing schema expectation tests**
+
+Update existing tests that assert schema version `4` or future schema `5` so current schema is `5` and future unsupported schema is `6`.
+
+- [ ] **Step 6: Run schema-related tests**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_workspace.py tests/test_workspace_evidence.py tests/test_workspace_server.py tests/test_workspace_reading_queue.py -v
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add src/papergraph/workspace.py tests/test_workspace.py tests/test_workspace_evidence.py tests/test_workspace_server.py tests/test_workspace_reading_queue.py
+git commit -m "feat: add reading queue workspace state"
+```
+
+---
+
+### Task 2: MCP Reading Queue Tools
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Create: `tests/test_workspace_reading_queue_server.py`
+
+**Interfaces:**
+- Consumes: workspace methods from Task 1
+- Produces: MCP wrappers `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, `workspace_apply_reading_queue_to_session`
+
+- [ ] **Step 1: Write failing MCP wrapper tests**
+
+Create `tests/test_workspace_reading_queue_server.py` with tests that open a workspace, import a small PDF fixture, create/get/list/apply a queue through server wrappers, and verify missing workspace or invalid IDs raise `ToolError`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_workspace_reading_queue_server.py -v
+```
+
+Expected: fail because MCP wrappers are missing.
+
+- [ ] **Step 3: Implement MCP wrappers**
+
+Add wrapper functions near the existing reading-session tools in `src/papergraph/server.py`. Each wrapper uses `require_workspace()` inside `_workspace_call` and forwards parameters to the workspace methods.
+
+- [ ] **Step 4: Run MCP wrapper tests**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_workspace_reading_queue_server.py -v
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_workspace_reading_queue_server.py
+git commit -m "feat: expose reading queue mcp tools"
+```
+
+---
+
+### Task 3: CLI Reading Queue Commands
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Create: `tests/test_cli_reading_queue.py`
+
+**Interfaces:**
+- Consumes: workspace methods from Task 1
+- Produces: commands `create-reading-queue`, `list-reading-queues`, `get-reading-queue`, `apply-reading-queue-to-session`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Create `tests/test_cli_reading_queue.py` with a JSON round-trip: create queue, list queues, get queue, create session, apply queue, and assert queued checkpoints appear in the session summary. Include an invalid ID test that verifies the existing JSON error envelope.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_cli_reading_queue.py -v
+```
+
+Expected: fail because CLI commands are missing.
+
+- [ ] **Step 3: Implement CLI parsers and command handlers**
+
+Add argparse subcommands in `build_parser()` and command branches in `main()` using `_workspace_json_command`, matching the existing reading-session command style.
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_cli_reading_queue.py -v
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_cli_reading_queue.py
+git commit -m "feat: add reading queue cli commands"
+```
+
+---
+
+### Task 4: v0.8.0 Documentation And Release Pins
+
+**Files:**
+- Modify: `README.md`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `scripts/check_onboarding.py`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+
+**Interfaces:**
+- Consumes: public MCP and CLI command names from Tasks 2 and 3
+- Produces: README workflow and active version pins for v0.8.0
+
+- [ ] **Step 1: Write/update documentation expectation tests**
+
+Update tests so repository metadata expects `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, `workspace_apply_reading_queue_to_session`, `create-reading-queue`, and `apply-reading-queue-to-session`. Update onboarding/version tests to expect `0.8.0`/`v0.8.0`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_repository.py tests/test_onboarding.py -v
+```
+
+Expected: fail until docs/version surfaces are updated.
+
+- [ ] **Step 3: Update README and version pins**
+
+Update README intro, feature list, tool list/table, quick-start pins, MCP config pins, and add a "Reading queue workflow" section. Update all active version pins from `0.7.0`/`v0.7.0` to `0.8.0`/`v0.8.0`, leaving historical release prose intact.
+
+- [ ] **Step 4: Run documentation/version tests**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_repository.py tests/test_onboarding.py tests/test_cli_reading_queue.py tests/test_workspace_reading_queue_server.py -v
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add README.md pyproject.toml uv.lock .github/workflows/ci.yml .github/ISSUE_TEMPLATE/bug_report.yml scripts/check_onboarding.py src/papergraph/arxiv.py .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/client-configuration.md tests/test_repository.py tests/test_onboarding.py
+git commit -m "docs: prepare v0.8.0 release"
+```
+
+---
+
+### Task 5: Full Verification, PR, Merge, Tag, Release
+
+**Files:**
+- No source edits unless verification exposes a defect.
+
+**Interfaces:**
+- Consumes: all prior task outputs
+- Produces: branch push, PR, main CI verification, `v0.8.0` tag, GitHub Release
+
+- [ ] **Step 1: Run full local suite**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest
+```
+
+Expected: `386+ passed, 1 skipped`, exact count depends on new tests.
+
+- [ ] **Step 2: Inspect git status and release pins**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --oneline --decorate --max-count=12
+rg -n "v0\.7\.0|0\.7\.0" README.md pyproject.toml uv.lock .github scripts src tests .agents/skills/setting-up-papergraph
+```
+
+Expected: clean worktree; remaining v0.7.0 references only in historical release prose/spec/plan text.
+
+- [ ] **Step 3: Push feature branch and create PR**
+
+Run:
+
+```powershell
+git push -u origin feature/v0.8-reading-queue
+```
+
+Then create a PR targeting `main` titled `Add Reading Queue Planner for v0.8.0` with summary and testing evidence. Prefer GitHub connector; fall back to GitHub REST using Git Credential Manager if connector permissions reject PR creation.
+
+- [ ] **Step 4: Merge/publish after CI**
+
+After PR or branch CI passes, merge to `main`. If PR creation is impossible because of GitHub integration/browser constraints, fast-forward `main` from the verified branch and record the deviation in the final report.
+
+- [ ] **Step 5: Tag and release**
+
+Create and push annotated `v0.8.0`, verify pinned install:
+
+```powershell
+git tag -a v0.8.0 -m "PaperGraph MCP v0.8.0"
+git push origin v0.8.0
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version
+```
+
+Create GitHub Release `PaperGraph MCP v0.8.0` after tag install verifies.
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: schema, planner semantics, API, MCP, CLI, docs, tests, and release are covered by Tasks 1-5.
+- Placeholder scan: no unfinished placeholders or undefined follow-up placeholders remain.
+- Type consistency: queue method names, tool names, CLI command names, statuses, target kinds, and priorities match the spec.

--- a/docs/superpowers/specs/2026-09-07-reading-queue-planner-v0.8-design.md
+++ b/docs/superpowers/specs/2026-09-07-reading-queue-planner-v0.8-design.md
@@ -1,0 +1,220 @@
+# Reading Queue Planner v0.8 Design
+
+## Goal
+
+PaperGraph v0.8.0 adds a persistent Reading Queue Planner that turns existing
+Reading Bridge evidence and v0.7 Reading Session State into a concrete,
+ordered list of targets an agent can review next.
+
+The planner must stay evidence-first. It may say that a target is queued
+because it is the selected result, a local proof dependency, a proof block, an
+external stop, an unresolved stop, or a warning-backed caution. It must not
+claim that a proof is correct, fill proof gaps, rank mathematical importance
+semantically, or invent missing dependencies.
+
+## User Workflow
+
+An agent opens a workspace, imports a paper, selects a target result, and asks
+PaperGraph for a reading queue. PaperGraph stores the queue in SQLite so the
+agent can reopen, inspect, and reuse it later.
+
+The expected workflow is:
+
+```text
+open_workspace(path="C:/Temp/papergraph-reading.sqlite3")
+workspace_add_pdf_paper(path="C:/Papers/example.pdf", paper_id="local:example")
+workspace_create_reading_queue(result_id="local:example::pdf:theorem:1.1", label="Main theorem queue")
+workspace_get_reading_queue(queue_id="queue:...")
+workspace_create_reading_session(paper_id="local:example", target_result_id="local:example::pdf:theorem:1.1")
+workspace_apply_reading_queue_to_session(queue_id="queue:...", session_id="session:...")
+workspace_export_reading_session_summary(session_id="session:...")
+```
+
+The same workflow must be available from the JSON CLI against an existing
+workspace.
+
+## Data Model
+
+The workspace schema advances from version 4 to version 5.
+
+Two tables are added:
+
+- `reading_queues`
+- `reading_queue_items`
+
+`reading_queues` stores queue metadata:
+
+- `queue_id`
+- `paper_id`
+- `target_result_id`
+- `label`
+- `status`
+- `created_at`
+- `updated_at`
+
+The only supported queue statuses for v0.8 are `active` and `archived`.
+
+`reading_queue_items` stores deterministic plan items:
+
+- `item_id`
+- `queue_id`
+- `position`
+- `target_kind`
+- `target_id`
+- `priority`
+- `reason`
+- `evidence_json`
+- `created_at`
+
+Supported target kinds match v0.7 session checkpoints:
+
+- `result_id`
+- `proof_id`
+- `span_id`
+- `external_stop`
+- `unresolved_stop`
+
+Supported priorities are:
+
+- `required`
+- `recommended`
+- `caution`
+
+Queue rows cascade when a paper is deleted. Queue items cascade when a queue is
+deleted.
+
+## Planner Semantics
+
+`create_reading_queue(result_id, label=None, recursive=True)` builds one queue
+from the selected result and its existing evidence.
+
+The queue order is deterministic:
+
+1. The selected `result_id` as `required`.
+2. The selected result's proof, if present, as `required`.
+3. Local result dependencies from `get_result_reading_path(result_id, recursive)`
+   in `top_down` order, excluding the selected result, as `recommended`.
+4. Proofs for those local dependency results, when present, immediately after
+   their result, as `recommended`.
+5. External stops from the reading path as `caution`.
+6. Unresolved stops from the reading path as `caution`.
+
+Duplicate `(target_kind, target_id)` pairs are omitted after their first
+occurrence.
+
+Each item includes a short deterministic `reason` and an `evidence` object. The
+evidence object includes enough provenance to recover the original bridge
+payload source without embedding generated explanation text.
+
+## Public Workspace API
+
+Add these methods to `Workspace`:
+
+```python
+def create_reading_queue(
+    self,
+    result_id: str,
+    label: str | None = None,
+    recursive: bool = True,
+) -> dict: ...
+
+def list_reading_queues(
+    self,
+    paper_id: str | None = None,
+    status: str | None = None,
+) -> list[dict]: ...
+
+def get_reading_queue(self, queue_id: str) -> dict: ...
+
+def apply_reading_queue_to_session(
+    self,
+    queue_id: str,
+    session_id: str,
+    status: str = "queued",
+) -> dict: ...
+```
+
+`create_reading_queue` returns the stored queue metadata plus item count.
+`get_reading_queue` returns `{"queue": ..., "items": [...]}`.
+`apply_reading_queue_to_session` validates that the queue and session belong to
+the same paper, records one reading checkpoint for each queue item with the
+requested status, and returns:
+
+```python
+{
+    "queue": queue_payload,
+    "session": session_payload,
+    "applied": [checkpoint_payload, ...],
+}
+```
+
+The apply status is restricted to v0.7 checkpoint statuses:
+
+- `queued`
+- `reviewed`
+- `blocked`
+- `skipped`
+
+The default is `queued`.
+
+## MCP Tools
+
+Expose these MCP tools:
+
+- `workspace_create_reading_queue(result_id: str, label: str | None = None, recursive: bool = True) -> dict`
+- `workspace_list_reading_queues(paper_id: str | None = None, status: str | None = None) -> list[dict]`
+- `workspace_get_reading_queue(queue_id: str) -> dict`
+- `workspace_apply_reading_queue_to_session(queue_id: str, session_id: str, status: str = "queued") -> dict`
+
+They must follow the existing `require_workspace()` and `_workspace_call`
+patterns so missing workspaces and validation errors surface as `ToolError`.
+
+## CLI
+
+Add JSON CLI commands:
+
+```powershell
+papergraph-mcp create-reading-queue --workspace C:/Temp/papergraph.sqlite3 --result-id local:example::pdf:theorem:1.1 --label "Main theorem queue"
+papergraph-mcp list-reading-queues --workspace C:/Temp/papergraph.sqlite3 --paper-id local:example
+papergraph-mcp get-reading-queue --workspace C:/Temp/papergraph.sqlite3 --queue-id queue:...
+papergraph-mcp apply-reading-queue-to-session --workspace C:/Temp/papergraph.sqlite3 --queue-id queue:... --session-id session:...
+```
+
+All commands print JSON using the existing CLI helper path and return the same
+error envelope style used by v0.6 and v0.7.
+
+## Documentation And Release
+
+The README should describe v0.8.0 as the release that adds persistent Reading
+Queue Planner support. The quick-start and MCP configuration pins should move
+from `v0.7.0` to `v0.8.0`, while historical v0.7.0 text remains as release
+history.
+
+The active version should become `0.8.0`.
+
+## Testing
+
+Tests must cover:
+
+- Schema v5 creates and migrates queue tables.
+- `create_reading_queue` emits deterministic ordered items from a PDF fixture
+  with a target result, proof, dependency, external stop, and unresolved stop.
+- Duplicate queue targets are omitted.
+- `list_reading_queues` and `get_reading_queue` are deterministic.
+- `apply_reading_queue_to_session` writes queued checkpoints using v0.7 session
+  state and rejects cross-paper queue/session combinations.
+- MCP wrappers return payloads and convert missing-workspace/errors.
+- CLI commands round-trip through JSON.
+- Repository metadata and README list the new tools and v0.8.0 pins.
+
+The full suite must pass locally before publishing. The GitHub Actions matrix
+on `main` must pass before creating the `v0.8.0` tag and release.
+
+## Non-Goals
+
+- No semantic theorem ranking.
+- No automatic arXiv citation import.
+- No proof verification.
+- No generated plain-language theorem or proof explanations.
+- No mutation of checkpoint status from queue state after apply; v0.7 reading
+  sessions remain the source of reading progress.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.7.0"
+version = "0.8.0"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.7.0"
+PAPERGRAPH_VERSION = "0.8.0"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.7.0"
+    "papergraph-mcp.git@v0.8.0"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -26,7 +26,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.7.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.8.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -550,6 +550,72 @@ def workspace_export_reading_session_summary(session_id: str) -> dict:
 
 
 @mcp.tool()
+@_serialized_workspace_tool
+def workspace_create_reading_queue(
+    result_id: str,
+    label: str | None = None,
+    recursive: bool = True,
+) -> dict:
+    """Create a persistent reading queue for one stored result."""
+
+    try:
+        return require_workspace().create_reading_queue(
+            result_id,
+            label=label,
+            recursive=recursive,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
+@_serialized_workspace_tool
+def workspace_list_reading_queues(
+    paper_id: str | None = None,
+    status: str | None = None,
+) -> list[dict]:
+    """List persistent reading queues in the active workspace."""
+
+    try:
+        return require_workspace().list_reading_queues(
+            paper_id=paper_id,
+            status=status,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
+@_serialized_workspace_tool
+def workspace_get_reading_queue(queue_id: str) -> dict:
+    """Return one persistent reading queue with ordered items."""
+
+    try:
+        return require_workspace().get_reading_queue(queue_id)
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
+@_serialized_workspace_tool
+def workspace_apply_reading_queue_to_session(
+    queue_id: str,
+    session_id: str,
+    status: str = "queued",
+) -> dict:
+    """Apply reading queue items as checkpoints in a reading session."""
+
+    try:
+        return require_workspace().apply_reading_queue_to_session(
+            queue_id,
+            session_id,
+            status=status,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
 def load_paper(path: str) -> dict:
     """Load a local LaTeX paper and build its theorem graph."""
 

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -985,6 +985,39 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
     session_summary_parser.add_argument("--workspace", required=True)
     session_summary_parser.add_argument("--session-id", required=True)
+    create_queue_parser = subparsers.add_parser(
+        "create-reading-queue",
+        help="Create a persistent reading queue for one result.",
+    )
+    create_queue_parser.add_argument("--workspace", required=True)
+    create_queue_parser.add_argument("--result-id", required=True)
+    create_queue_parser.add_argument("--label")
+    create_queue_parser.add_argument(
+        "--direct",
+        action="store_true",
+        help="Queue only direct local dependencies instead of recursive traversal.",
+    )
+    list_queues_parser = subparsers.add_parser(
+        "list-reading-queues",
+        help="List persistent reading queues in a workspace.",
+    )
+    list_queues_parser.add_argument("--workspace", required=True)
+    list_queues_parser.add_argument("--paper-id")
+    list_queues_parser.add_argument("--status")
+    get_queue_parser = subparsers.add_parser(
+        "get-reading-queue",
+        help="Return one reading queue with ordered items.",
+    )
+    get_queue_parser.add_argument("--workspace", required=True)
+    get_queue_parser.add_argument("--queue-id", required=True)
+    apply_queue_parser = subparsers.add_parser(
+        "apply-reading-queue-to-session",
+        help="Apply queue items as reading session checkpoints.",
+    )
+    apply_queue_parser.add_argument("--workspace", required=True)
+    apply_queue_parser.add_argument("--queue-id", required=True)
+    apply_queue_parser.add_argument("--session-id", required=True)
+    apply_queue_parser.add_argument("--status", default="queued")
 
     args = parser.parse_args(argv)
     if args.command == "doctor":
@@ -1123,6 +1156,45 @@ def main(argv: Sequence[str] | None = None) -> None:
             args.workspace,
             lambda workspace: workspace.export_reading_session_summary(
                 args.session_id,
+            ),
+        )
+        return
+    if args.command == "create-reading-queue":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.create_reading_queue(
+                args.result_id,
+                label=args.label,
+                recursive=not args.direct,
+            ),
+        )
+        return
+    if args.command == "list-reading-queues":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.list_reading_queues(
+                paper_id=args.paper_id,
+                status=args.status,
+            ),
+        )
+        return
+    if args.command == "get-reading-queue":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.get_reading_queue(args.queue_id),
+        )
+        return
+    if args.command == "apply-reading-queue-to-session":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.apply_reading_queue_to_session(
+                args.queue_id,
+                args.session_id,
+                status=args.status,
             ),
         )
         return

--- a/src/papergraph/workspace.py
+++ b/src/papergraph/workspace.py
@@ -45,7 +45,7 @@ from papergraph.reading import (
 )
 
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 _RESOLVED_RESOLUTION_STATUSES = (
     "resolved",
     "resolved_bibliography_entry",
@@ -63,6 +63,8 @@ _READING_TARGET_KINDS = {
 }
 _READING_NOTE_TARGET_KINDS = {*_READING_TARGET_KINDS, "session"}
 _READING_NOTE_TYPES = {"note", "question", "warning", "decision"}
+_READING_QUEUE_STATUSES = {"active", "archived"}
+_READING_QUEUE_ITEM_PRIORITIES = {"required", "recommended", "caution"}
 _REQUIRED_TABLES = {
     "workspace_meta",
     "papers",
@@ -83,6 +85,8 @@ _REQUIRED_TABLES = {
     "reading_sessions",
     "reading_checkpoints",
     "reading_notes",
+    "reading_queues",
+    "reading_queue_items",
 }
 _REQUIRED_THEOREM_COLUMNS = {
     "global_id",
@@ -233,6 +237,26 @@ _REQUIRED_TABLE_COLUMNS = {
         "target_id",
         "note_type",
         "text",
+        "created_at",
+    },
+    "reading_queues": {
+        "queue_id",
+        "paper_id",
+        "target_result_id",
+        "label",
+        "status",
+        "created_at",
+        "updated_at",
+    },
+    "reading_queue_items": {
+        "item_id",
+        "queue_id",
+        "position",
+        "target_kind",
+        "target_id",
+        "priority",
+        "reason",
+        "evidence_json",
         "created_at",
     },
 }
@@ -450,6 +474,45 @@ CREATE INDEX reading_notes_session
     ON reading_notes(session_id, created_at, note_id);
 """
 
+_READING_QUEUE_SCHEMA_SQL = """
+CREATE TABLE reading_queues (
+    queue_id TEXT PRIMARY KEY,
+    paper_id TEXT NOT NULL REFERENCES papers(paper_id) ON DELETE CASCADE,
+    target_result_id TEXT REFERENCES results(result_id) ON DELETE SET NULL,
+    label TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('active', 'archived')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE TABLE reading_queue_items (
+    item_id TEXT PRIMARY KEY,
+    queue_id TEXT NOT NULL REFERENCES reading_queues(queue_id)
+        ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    target_kind TEXT NOT NULL CHECK (
+        target_kind IN (
+            'result_id',
+            'proof_id',
+            'span_id',
+            'external_stop',
+            'unresolved_stop'
+        )
+    ),
+    target_id TEXT NOT NULL,
+    priority TEXT NOT NULL CHECK (
+        priority IN ('required', 'recommended', 'caution')
+    ),
+    reason TEXT NOT NULL,
+    evidence_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE (queue_id, target_kind, target_id)
+);
+CREATE INDEX reading_queues_paper_status
+    ON reading_queues(paper_id, status, updated_at, queue_id);
+CREATE INDEX reading_queue_items_queue
+    ON reading_queue_items(queue_id, position, item_id);
+"""
+
 _SCHEMA_SQL = """
 CREATE TABLE workspace_meta (
     key TEXT PRIMARY KEY,
@@ -494,8 +557,8 @@ CREATE INDEX theorems_paper_kind ON theorems(paper_id, normalized_kind);
 CREATE INDEX citations_source ON citation_evidence(source_paper_id);
 CREATE INDEX citations_target ON citation_evidence(target_paper_id);
 CREATE INDEX citations_arxiv ON citation_evidence(cited_arxiv_id);
-""" + _EVIDENCE_SCHEMA_SQL + _READING_SESSION_SCHEMA_SQL + """
-INSERT INTO workspace_meta (key, value) VALUES ('schema_version', '4');
+""" + _EVIDENCE_SCHEMA_SQL + _READING_SESSION_SCHEMA_SQL + _READING_QUEUE_SCHEMA_SQL + """
+INSERT INTO workspace_meta (key, value) VALUES ('schema_version', '5');
 """
 
 
@@ -599,6 +662,15 @@ class Workspace:
                 )
             }
             schema_version = 4
+        if schema_version == 4:
+            Workspace._migrate_v4_to_v5(connection)
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+            schema_version = 5
         if schema_version != SCHEMA_VERSION:
             raise WorkspaceSchemaError(
                 f"Unsupported workspace schema version {schema_version}; "
@@ -670,6 +742,27 @@ class Workspace:
         try:
             connection.execute("BEGIN")
             _execute_sql_script(connection, _READING_SESSION_SCHEMA_SQL)
+            connection.execute(
+                "UPDATE workspace_meta SET value = ? WHERE key = 'schema_version'",
+                (str(SCHEMA_VERSION),),
+            )
+            connection.execute("COMMIT")
+        except Exception:
+            if connection.in_transaction:
+                connection.execute("ROLLBACK")
+            raise
+
+        violations = connection.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise WorkspaceSchemaError(
+                "Workspace schema migration left foreign key violations"
+            )
+
+    @staticmethod
+    def _migrate_v4_to_v5(connection: sqlite3.Connection) -> None:
+        try:
+            connection.execute("BEGIN")
+            _execute_sql_script(connection, _READING_QUEUE_SCHEMA_SQL)
             connection.execute(
                 "UPDATE workspace_meta SET value = ? WHERE key = 'schema_version'",
                 (str(SCHEMA_VERSION),),
@@ -1535,6 +1628,148 @@ class Workspace:
         }
 
     @_synchronized
+    def create_reading_queue(
+        self,
+        result_id: str,
+        label: str | None = None,
+        recursive: bool = True,
+    ) -> dict:
+        """Create a persistent reading queue for one stored result."""
+
+        result = self.get_result(result_id)
+        normalized_label = _clean_required_text(
+            label if label is not None else result_id,
+            "reading queue label",
+        )
+        timestamp = datetime.now(timezone.utc).isoformat()
+        queue_id = self._new_reading_queue_id(normalized_label, timestamp)
+        items = self._planned_reading_queue_items(result_id, recursive)
+
+        self._connection.execute(
+            """
+            INSERT INTO reading_queues (
+                queue_id, paper_id, target_result_id, label, status,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, 'active', ?, ?)
+            """,
+            (
+                queue_id,
+                result["paper_id"],
+                result_id,
+                normalized_label,
+                timestamp,
+                timestamp,
+            ),
+        )
+        for position, item in enumerate(items, start=1):
+            self._connection.execute(
+                """
+                INSERT INTO reading_queue_items (
+                    item_id, queue_id, position, target_kind, target_id,
+                    priority, reason, evidence_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self._new_reading_queue_item_id(queue_id, position),
+                    queue_id,
+                    position,
+                    item["target_kind"],
+                    item["target_id"],
+                    item["priority"],
+                    item["reason"],
+                    _json_payload(item["evidence"], "reading queue item evidence"),
+                    timestamp,
+                ),
+            )
+        self._connection.commit()
+        return self._reading_queue_payload(queue_id)
+
+    @_synchronized
+    def list_reading_queues(
+        self,
+        paper_id: str | None = None,
+        status: str | None = None,
+    ) -> list[dict]:
+        """List reading queues ordered for resumption."""
+
+        conditions: list[str] = []
+        parameters: list[str] = []
+        if paper_id is not None:
+            normalized_paper_id = normalize_paper_id(paper_id)
+            self.get_paper(normalized_paper_id)
+            conditions.append("paper_id = ?")
+            parameters.append(normalized_paper_id)
+        if status is not None:
+            _validate_choice(status, _READING_QUEUE_STATUSES, "reading queue status")
+            conditions.append("status = ?")
+            parameters.append(status)
+        where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        rows = self._connection.execute(
+            f"""
+            SELECT
+                queue_id, paper_id, target_result_id, label, status,
+                created_at, updated_at
+            FROM reading_queues
+            {where_clause}
+            ORDER BY updated_at DESC, queue_id DESC
+            """,
+            parameters,
+        ).fetchall()
+        return [self._reading_queue_payload_from_row(row) for row in rows]
+
+    @_synchronized
+    def get_reading_queue(self, queue_id: str) -> dict:
+        """Return one reading queue with deterministic item ordering."""
+
+        return {
+            "queue": self._reading_queue_payload(queue_id),
+            "items": self._reading_queue_items(queue_id),
+        }
+
+    @_synchronized
+    def apply_reading_queue_to_session(
+        self,
+        queue_id: str,
+        session_id: str,
+        status: str = "queued",
+    ) -> dict:
+        """Create session checkpoints from one reading queue."""
+
+        _validate_choice(status, _READING_CHECKPOINT_STATUSES, "reading checkpoint status")
+        queue = self._reading_queue_payload(queue_id)
+        session = self._reading_session_payload(session_id)
+        if queue["paper_id"] != session["paper_id"]:
+            raise ValueError(
+                f"Reading queue {queue_id!r} does not belong to the same paper "
+                f"as reading session {session_id!r}"
+            )
+
+        applied = []
+        for item in self._reading_queue_items(queue_id):
+            applied.append(
+                self.record_reading_checkpoint(
+                    session_id,
+                    item["target_kind"],
+                    item["target_id"],
+                    status,
+                    summary=item["reason"],
+                    evidence={
+                        "source": "reading_queue",
+                        "queue_id": queue_id,
+                        "item_id": item["item_id"],
+                        "priority": item["priority"],
+                        "reason": item["reason"],
+                        "item_evidence": item["evidence"],
+                    },
+                )
+            )
+        return {
+            "queue": self._reading_queue_payload(queue_id),
+            "session": self._reading_session_payload(session_id),
+            "applied": applied,
+        }
+
+    @_synchronized
     def counts(self) -> dict[str, int]:
         """Return the total paper and theorem counts."""
 
@@ -2000,6 +2235,190 @@ class Workspace:
             (session_id,),
         ).fetchall()
         return [_reading_note_from_row(row) for row in rows]
+
+    def _new_reading_queue_id(self, label: str, timestamp: str) -> str:
+        base = "queue:" + _reading_session_slug(label)
+        compact_timestamp = (
+            timestamp.replace("-", "")
+            .replace(":", "")
+            .replace("+", "")
+            .replace(".", "")
+        )
+        candidate = f"{base}:{compact_timestamp[:14]}"
+        suffix = 2
+        while self._connection.execute(
+            "SELECT 1 FROM reading_queues WHERE queue_id = ?",
+            (candidate,),
+        ).fetchone():
+            candidate = f"{base}:{compact_timestamp[:14]}-{suffix}"
+            suffix += 1
+        return candidate
+
+    def _new_reading_queue_item_id(self, queue_id: str, position: int) -> str:
+        return f"{queue_id}::item:{position}"
+
+    def _reading_queue_payload(self, queue_id: str) -> dict:
+        row = self._connection.execute(
+            """
+            SELECT
+                queue_id, paper_id, target_result_id, label, status,
+                created_at, updated_at
+            FROM reading_queues
+            WHERE queue_id = ?
+            """,
+            (queue_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown reading queue id: {queue_id}")
+        return self._reading_queue_payload_from_row(row)
+
+    def _reading_queue_payload_from_row(self, row: tuple) -> dict:
+        queue_id = row[0]
+        item_count = self._connection.execute(
+            "SELECT COUNT(*) FROM reading_queue_items WHERE queue_id = ?",
+            (queue_id,),
+        ).fetchone()[0]
+        return {
+            "queue_id": queue_id,
+            "paper_id": row[1],
+            "target_result_id": row[2],
+            "label": row[3],
+            "status": row[4],
+            "created_at": row[5],
+            "updated_at": row[6],
+            "counts": {"items": item_count},
+        }
+
+    def _reading_queue_items(self, queue_id: str) -> list[dict]:
+        self._reading_queue_payload(queue_id)
+        rows = self._connection.execute(
+            """
+            SELECT
+                item_id, queue_id, position, target_kind, target_id, priority,
+                reason, evidence_json, created_at
+            FROM reading_queue_items
+            WHERE queue_id = ?
+            ORDER BY position, item_id
+            """,
+            (queue_id,),
+        ).fetchall()
+        return [_reading_queue_item_from_row(row) for row in rows]
+
+    def _planned_reading_queue_items(
+        self,
+        result_id: str,
+        recursive: bool,
+    ) -> list[dict]:
+        path = self.get_result_reading_path(result_id, recursive=recursive)
+        planned: list[dict] = []
+        seen: set[tuple[str, str]] = set()
+
+        def add(
+            target_kind: str,
+            target_id: str,
+            priority: str,
+            reason: str,
+            evidence: dict,
+        ) -> None:
+            key = (target_kind, target_id)
+            if key in seen:
+                return
+            seen.add(key)
+            planned.append(
+                {
+                    "target_kind": target_kind,
+                    "target_id": target_id,
+                    "priority": priority,
+                    "reason": reason,
+                    "evidence": evidence,
+                }
+            )
+
+        add(
+            "result_id",
+            result_id,
+            "required",
+            "selected_result",
+            {
+                "source": "reading_path.result_id",
+                "result_id": result_id,
+                "recursive": recursive,
+            },
+        )
+        selected_proof = self._proof_for_result(result_id)
+        if selected_proof is not None:
+            add(
+                "proof_id",
+                selected_proof["proof_id"],
+                "required",
+                "selected_result_proof",
+                {
+                    "source": "result_proof",
+                    "result_id": result_id,
+                    "proof_id": selected_proof["proof_id"],
+                },
+            )
+
+        for dependency in path["top_down"]:
+            dependency_id = dependency["result_id"]
+            if dependency_id == result_id:
+                continue
+            add(
+                "result_id",
+                dependency_id,
+                "recommended",
+                "local_dependency_result",
+                {
+                    "source": "reading_path.top_down",
+                    "result_id": result_id,
+                    "dependency_result_id": dependency_id,
+                },
+            )
+            proof = self._proof_for_result(dependency_id)
+            if proof is not None:
+                add(
+                    "proof_id",
+                    proof["proof_id"],
+                    "recommended",
+                    "local_dependency_proof",
+                    {
+                        "source": "result_proof",
+                        "result_id": dependency_id,
+                        "proof_id": proof["proof_id"],
+                    },
+                )
+
+        for mention in path["external_stops"]:
+            add(
+                "external_stop",
+                mention["mention_id"],
+                "caution",
+                "external_dependency_stop",
+                {
+                    "source": "reading_path.external_stops",
+                    "mention_id": mention["mention_id"],
+                    "raw_text": mention.get("raw_text"),
+                    "resolution_status": mention.get("resolution_status"),
+                },
+            )
+
+        for stop in path["unresolved_stops"]:
+            stop_id = f"{stop['result_id']}:{stop['kind']}"
+            add(
+                "unresolved_stop",
+                stop_id,
+                "caution",
+                "unresolved_dependency_stop",
+                {
+                    "source": "reading_path.unresolved_stops",
+                    "result_id": stop["result_id"],
+                    "kind": stop["kind"],
+                    "mention_count": len(stop["mentions"]),
+                    "mentions": stop["mentions"],
+                },
+            )
+
+        return planned
 
     @_synchronized
     def get_paper(self, paper_id: str) -> dict:
@@ -3540,6 +3959,20 @@ def _reading_note_from_row(row: tuple) -> dict:
         "note_type": row[4],
         "text": row[5],
         "created_at": row[6],
+    }
+
+
+def _reading_queue_item_from_row(row: tuple) -> dict:
+    return {
+        "item_id": row[0],
+        "queue_id": row[1],
+        "position": row[2],
+        "target_kind": row[3],
+        "target_id": row[4],
+        "priority": row[5],
+        "reason": row[6],
+        "evidence": json.loads(row[7]),
+        "created_at": row[8],
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.7.0\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.8.0\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,11 +74,11 @@ def test_doctor_prints_json_without_starting_mcp(
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.7.0",
-            "release_tag": "v0.7.0",
+            "version": "0.8.0",
+            "release_tag": "v0.8.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.7.0"
+                "papergraph-mcp.git@v0.8.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -88,7 +88,7 @@ def test_doctor_prints_json_without_starting_mcp(
 
     server.main(["doctor"])
 
-    assert json.loads(capsys.readouterr().out)["version"] == "0.7.0"
+    assert json.loads(capsys.readouterr().out)["version"] == "0.8.0"
 
 
 def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(

--- a/tests/test_cli_reading_queue.py
+++ b/tests/test_cli_reading_queue.py
@@ -1,0 +1,156 @@
+import json
+from pathlib import Path
+
+import fitz
+import pytest
+
+import papergraph.server as server
+from papergraph.workspace import Workspace
+
+
+def write_queue_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def create_queue_workspace(tmp_path: Path) -> Path:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_queue_pdf(pdf)
+    workspace = Workspace.open(workspace_path)
+    try:
+        workspace.import_pdf(pdf, "local:paper")
+    finally:
+        workspace.close()
+    return workspace_path
+
+
+def read_json(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_create_reading_queue_cli_prints_json(tmp_path: Path, capsys):
+    workspace_path = create_queue_workspace(tmp_path)
+
+    server.main(
+        [
+            "create-reading-queue",
+            "--workspace",
+            str(workspace_path),
+            "--result-id",
+            "local:paper::pdf:theorem:1.1",
+            "--label",
+            "Main theorem queue",
+        ]
+    )
+
+    payload = read_json(capsys)
+    assert payload["paper_id"] == "local:paper"
+    assert payload["target_result_id"] == "local:paper::pdf:theorem:1.1"
+    assert payload["status"] == "active"
+    assert payload["counts"] == {"items": 5}
+
+
+def test_reading_queue_cli_round_trip(tmp_path: Path, capsys):
+    workspace_path = create_queue_workspace(tmp_path)
+    server.main(
+        [
+            "create-reading-queue",
+            "--workspace",
+            str(workspace_path),
+            "--result-id",
+            "local:paper::pdf:theorem:1.1",
+        ]
+    )
+    queue_id = read_json(capsys)["queue_id"]
+
+    server.main(["list-reading-queues", "--workspace", str(workspace_path)])
+    listed = json.loads(capsys.readouterr().out)
+    assert [item["queue_id"] for item in listed] == [queue_id]
+
+    server.main(
+        [
+            "get-reading-queue",
+            "--workspace",
+            str(workspace_path),
+            "--queue-id",
+            queue_id,
+        ]
+    )
+    full = read_json(capsys)
+    assert full["queue"]["counts"] == {"items": 5}
+    assert full["items"][0]["target_kind"] == "result_id"
+
+    server.main(
+        [
+            "create-reading-session",
+            "--workspace",
+            str(workspace_path),
+            "--paper-id",
+            "local:paper",
+            "--target-result-id",
+            "local:paper::pdf:theorem:1.1",
+        ]
+    )
+    session_id = read_json(capsys)["session_id"]
+
+    server.main(
+        [
+            "apply-reading-queue-to-session",
+            "--workspace",
+            str(workspace_path),
+            "--queue-id",
+            queue_id,
+            "--session-id",
+            session_id,
+        ]
+    )
+    applied = read_json(capsys)
+    assert len(applied["applied"]) == 5
+
+    server.main(
+        [
+            "export-reading-session-summary",
+            "--workspace",
+            str(workspace_path),
+            "--session-id",
+            session_id,
+        ]
+    )
+    summary = read_json(capsys)
+    assert summary["progress"]["queued"] == 5
+    assert summary["next_actions"] == ["continue_queued_targets"]
+
+
+def test_get_reading_queue_cli_reports_unknown_queue(tmp_path: Path, capsys):
+    workspace_path = create_queue_workspace(tmp_path)
+
+    with pytest.raises(SystemExit) as caught:
+        server.main(
+            [
+                "get-reading-queue",
+                "--workspace",
+                str(workspace_path),
+                "--queue-id",
+                "queue:missing",
+            ]
+        )
+
+    assert caught.value.code == 1
+    payload = read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["command"] == "get-reading-queue"
+    assert "Unknown reading queue id" in payload["message"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,11 +5,11 @@ def test_environment_diagnostics_reports_version_and_release_source():
     result = environment_diagnostics()
 
     assert result["package_name"] == "papergraph-mcp"
-    assert result["version"] == "0.7.0"
-    assert result["release_tag"] == "v0.7.0"
+    assert result["version"] == "0.8.0"
+    assert result["release_tag"] == "v0.8.0"
     assert (
         result["recommended_source"]
-        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0"
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0"
     )
     assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
     assert isinstance(result["warnings"], list)
@@ -25,6 +25,6 @@ def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
 
     result = environment_diagnostics()
 
-    assert result["version"] == "0.7.0"
+    assert result["version"] == "0.8.0"
     assert result["git"] is None
     assert any("Git context unavailable" in warning for warning in result["warnings"])

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.7.0"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.7.0\n"
+        stdout = "papergraph-mcp 0.8.0\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.7.0"
+    assert result["version"] == "papergraph-mcp 0.8.0"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.7.0"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.8.0"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -350,7 +350,7 @@ def test_readme_exposes_agent_guided_setup():
     assert ".agents/skills/setting-up-papergraph/SKILL.md" in text
 
 
-def test_all_onboarding_source_pins_match_v061():
+def test_all_onboarding_source_pins_match_v080():
     import re
 
     combined = "\n".join(
@@ -361,4 +361,4 @@ def test_all_onboarding_source_pins_match_v061():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.7.0"}
+    assert set(refs) == {"v0.8.0"}

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,7 +24,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.7.0"
+    assert project["version"] == "0.8.0"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -70,7 +70,7 @@ def test_lockfile_contains_project_package():
     )
 
     assert package["name"] == "papergraph-mcp"
-    assert package["version"] == "0.7.0"
+    assert package["version"] == "0.8.0"
 
 
 def test_validate_arxiv_request_module_stdout_is_json_only():
@@ -102,8 +102,8 @@ def test_runtime_and_issue_template_release_strings_remain_pinned():
         if item.get("id") == "version"
     )
 
-    assert f'PaperGraph/0.7.0 (+{REPOSITORY_URL})' in arxiv_source
-    assert version_field["attributes"]["placeholder"] == "0.7.0"
+    assert f'PaperGraph/0.8.0 (+{REPOSITORY_URL})' in arxiv_source
+    assert version_field["attributes"]["placeholder"] == "0.8.0"
 
 
 def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
@@ -144,7 +144,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.7.0" in build_steps
+    assert "papergraph-mcp 0.8.0" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -252,7 +252,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.7.0"
+        "papergraph-mcp.git@v0.8.0"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):
@@ -263,7 +263,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     )
     assert '"command": "uvx"' in readme
     assert pinned_source in readme
-    assert "PaperGraph v0.7.0" in readme
+    assert "PaperGraph v0.8.0" in readme
 
     for tool_name in (
         "load_paper",
@@ -303,6 +303,10 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
         "workspace_record_reading_checkpoint",
         "workspace_add_reading_note",
         "workspace_export_reading_session_summary",
+        "workspace_create_reading_queue",
+        "workspace_list_reading_queues",
+        "workspace_get_reading_queue",
+        "workspace_apply_reading_queue_to_session",
     ):
         assert f"`{tool_name}`" in readme
 
@@ -322,6 +326,10 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     assert "record-reading-checkpoint" in readme
     assert "add-reading-note" in readme
     assert "export-reading-session-summary" in readme
+    assert "create-reading-queue" in readme
+    assert "list-reading-queues" in readme
+    assert "get-reading-queue" in readme
+    assert "apply-reading-queue-to-session" in readme
     assert "--workspace" in readme
     assert "`get_environment_diagnostics`" in readme
     assert "`validate_arxiv_request`" in readme
@@ -380,8 +388,8 @@ def test_onboarding_uses_v061_release_pin_and_mentions_id_url_conflicts():
         ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
     ).read_text(encoding="utf-8")
 
-    assert "papergraph-mcp.git@v0.7.0" in skill
-    assert "papergraph-mcp 0.7.0" in skill
+    assert "papergraph-mcp.git@v0.8.0" in skill
+    assert "papergraph-mcp 0.8.0" in skill
     assert "validate_arxiv_request" in skill
     assert "load_arxiv_request" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,11 +169,11 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.7.0",
-            "release_tag": "v0.7.0",
+            "version": "0.8.0",
+            "release_tag": "v0.8.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.7.0"
+                "papergraph-mcp.git@v0.8.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -181,7 +181,7 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         },
     )
 
-    assert server.get_environment_diagnostics()["release_tag"] == "v0.7.0"
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.8.0"
 
 
 def test_validate_arxiv_input_tool_reports_conflict():

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -109,14 +109,16 @@ def test_workspace_creates_versioned_schema_and_only_the_parent(tmp_path: Path):
         "external_result_mentions",
         "evidence_edges",
         "evidence_edge_source_spans",
-        "reading_sessions",
-        "reading_checkpoints",
-        "reading_notes",
-    }
+            "reading_sessions",
+            "reading_checkpoints",
+            "reading_notes",
+            "reading_queues",
+            "reading_queue_items",
+        }
     assert fetch_all(
         path,
         "SELECT value FROM workspace_meta WHERE key = 'schema_version'",
-    ) == [("4",)]
+    ) == [("5",)]
 
 
 def test_workspace_rejects_a_directory_path(tmp_path: Path):
@@ -137,7 +139,7 @@ def test_workspace_rejects_newer_schema_and_closes_connection(
             "CREATE TABLE workspace_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
         )
         connection.execute(
-            "INSERT INTO workspace_meta VALUES ('schema_version', '5')"
+            "INSERT INTO workspace_meta VALUES ('schema_version', '6')"
         )
 
     import papergraph.workspace as workspace_module
@@ -152,7 +154,7 @@ def test_workspace_rejects_newer_schema_and_closes_connection(
 
     monkeypatch.setattr(workspace_module.sqlite3, "connect", tracking_connect)
 
-    with pytest.raises(WorkspaceSchemaError, match="schema version 5"):
+    with pytest.raises(WorkspaceSchemaError, match="schema version 6"):
         Workspace.open(path)
 
     with pytest.raises(sqlite3.ProgrammingError, match="closed"):
@@ -166,7 +168,7 @@ def test_workspace_rejects_partial_current_schema(tmp_path: Path):
             "CREATE TABLE workspace_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
         )
         connection.execute(
-            "INSERT INTO workspace_meta VALUES ('schema_version', '4')"
+            "INSERT INTO workspace_meta VALUES ('schema_version', '5')"
         )
 
     with pytest.raises(WorkspaceSchemaError, match="missing required tables.*papers"):

--- a/tests/test_workspace_evidence.py
+++ b/tests/test_workspace_evidence.py
@@ -230,7 +230,7 @@ def document_with_direct_span_backed_bibliography_edge() -> EvidenceDocument:
 def test_schema_v4_initializes_evidence_tables(tmp_path: Path):
     workspace = Workspace.open(tmp_path / "workspace.sqlite3")
     try:
-        assert SCHEMA_VERSION == 4
+        assert SCHEMA_VERSION == 5
         tables = {
             row[0]
             for row in workspace._connection.execute(
@@ -246,7 +246,7 @@ def test_schema_v4_initializes_evidence_tables(tmp_path: Path):
         } <= tables
         assert workspace._connection.execute(
             "SELECT value FROM workspace_meta WHERE key = 'schema_version'"
-        ).fetchone() == ("4",)
+        ).fetchone() == ("5",)
     finally:
         workspace.close()
 
@@ -447,7 +447,7 @@ def test_v2_workspace_migrates_without_losing_legacy_tables(tmp_path: Path):
     try:
         assert workspace._connection.execute(
             "SELECT value FROM workspace_meta WHERE key = 'schema_version'"
-        ).fetchone() == ("4",)
+        ).fetchone() == ("5",)
         assert workspace.get_paper("local:old")["paper_id"] == "local:old"
     finally:
         workspace.close()

--- a/tests/test_workspace_reading_queue.py
+++ b/tests/test_workspace_reading_queue.py
@@ -1,0 +1,212 @@
+import sqlite3
+from pathlib import Path
+
+import fitz
+import pytest
+
+from papergraph.workspace import SCHEMA_VERSION, Workspace
+
+
+def write_queue_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2, Lemma 9.9, and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def import_queue_pdf(tmp_path: Path, paper_id: str = "local:paper") -> tuple[Path, str]:
+    workspace_path = tmp_path / f"{paper_id.replace(':', '-')}.sqlite3"
+    pdf = tmp_path / f"{paper_id.replace(':', '-')}.pdf"
+    write_queue_pdf(pdf)
+    workspace = Workspace.open(workspace_path)
+    try:
+        workspace.import_pdf(pdf, paper_id)
+    finally:
+        workspace.close()
+    return workspace_path, f"{paper_id}::pdf:theorem:1.1"
+
+
+def test_schema_v5_initializes_reading_queue_tables(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        assert SCHEMA_VERSION == 5
+        tables = {
+            row[0]
+            for row in workspace._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert {"reading_queues", "reading_queue_items"} <= tables
+        assert workspace._connection.execute(
+            "SELECT value FROM workspace_meta WHERE key = 'schema_version'"
+        ).fetchone() == ("5",)
+    finally:
+        workspace.close()
+
+
+def test_v4_workspace_migrates_to_v5_without_losing_session_state(tmp_path: Path):
+    workspace_path, result_id = import_queue_pdf(tmp_path)
+    workspace = Workspace.open(workspace_path)
+    try:
+        session = workspace.create_reading_session(
+            "local:paper",
+            target_result_id=result_id,
+        )
+    finally:
+        workspace.close()
+
+    with sqlite3.connect(workspace_path) as connection:
+        connection.execute("DROP TABLE reading_queue_items")
+        connection.execute("DROP TABLE reading_queues")
+        connection.execute(
+            "UPDATE workspace_meta SET value = '4' WHERE key = 'schema_version'"
+        )
+
+    workspace = Workspace.open(workspace_path)
+    try:
+        assert workspace._connection.execute(
+            "SELECT value FROM workspace_meta WHERE key = 'schema_version'"
+        ).fetchone() == ("5",)
+        assert workspace.get_result(result_id)["result_id"] == result_id
+        assert workspace.get_reading_session(session["session_id"])["session"][
+            "session_id"
+        ] == session["session_id"]
+        assert workspace.list_reading_queues() == []
+    finally:
+        workspace.close()
+
+
+def test_create_reading_queue_orders_targets_by_evidence_path(tmp_path: Path):
+    workspace_path, result_id = import_queue_pdf(tmp_path)
+    workspace = Workspace.open(workspace_path)
+    try:
+        queue = workspace.create_reading_queue(
+            result_id,
+            label="Main theorem queue",
+            recursive=True,
+        )
+
+        assert queue["queue_id"].startswith("queue:main-theorem-queue:")
+        assert queue["paper_id"] == "local:paper"
+        assert queue["target_result_id"] == result_id
+        assert queue["label"] == "Main theorem queue"
+        assert queue["status"] == "active"
+        assert queue["counts"] == {"items": 6}
+
+        full = workspace.get_reading_queue(queue["queue_id"])
+        items = full["items"]
+        assert [
+            (item["position"], item["target_kind"], item["target_id"], item["priority"])
+            for item in items
+        ] == [
+            (1, "result_id", "local:paper::pdf:theorem:1.1", "required"),
+            (2, "proof_id", "local:paper::proof:2", "required"),
+            (3, "result_id", "local:paper::pdf:lemma:1.2", "recommended"),
+            (4, "proof_id", "local:paper::proof:1", "recommended"),
+            (5, "external_stop", "local:paper::external-mention:1", "caution"),
+            (
+                6,
+                "unresolved_stop",
+                "local:paper::pdf:theorem:1.1:local_result_mentions",
+                "caution",
+            ),
+        ]
+        assert items[0]["reason"] == "selected_result"
+        assert items[4]["evidence"]["source"] == "reading_path.external_stops"
+        assert items[5]["evidence"]["source"] == "reading_path.unresolved_stops"
+        assert items[5]["evidence"]["mention_count"] == 1
+    finally:
+        workspace.close()
+
+
+def test_create_reading_queue_omits_duplicate_targets(tmp_path: Path):
+    workspace_path, result_id = import_queue_pdf(tmp_path)
+    workspace = Workspace.open(workspace_path)
+    try:
+        queue = workspace.create_reading_queue(result_id)
+        full = workspace.get_reading_queue(queue["queue_id"])
+        pairs = [(item["target_kind"], item["target_id"]) for item in full["items"]]
+
+        assert len(pairs) == len(set(pairs))
+    finally:
+        workspace.close()
+
+
+def test_list_and_get_reading_queues_are_deterministic(tmp_path: Path):
+    workspace_path, result_id = import_queue_pdf(tmp_path)
+    workspace = Workspace.open(workspace_path)
+    try:
+        first = workspace.create_reading_queue(result_id, label="First queue")
+        second = workspace.create_reading_queue(result_id, label="Second queue")
+
+        listed = workspace.list_reading_queues(paper_id="local:paper")
+
+        assert [queue["queue_id"] for queue in listed] == [
+            second["queue_id"],
+            first["queue_id"],
+        ]
+        full = workspace.get_reading_queue(second["queue_id"])
+        assert full["queue"]["queue_id"] == second["queue_id"]
+        assert full["items"][0]["target_id"] == result_id
+    finally:
+        workspace.close()
+
+
+def test_apply_reading_queue_to_session_creates_queued_checkpoints(
+    tmp_path: Path,
+):
+    workspace_path, result_id = import_queue_pdf(tmp_path)
+    workspace = Workspace.open(workspace_path)
+    try:
+        queue = workspace.create_reading_queue(result_id)
+        session = workspace.create_reading_session(
+            "local:paper",
+            target_result_id=result_id,
+        )
+
+        applied = workspace.apply_reading_queue_to_session(
+            queue["queue_id"],
+            session["session_id"],
+        )
+
+        assert applied["queue"]["queue_id"] == queue["queue_id"]
+        assert applied["session"]["session_id"] == session["session_id"]
+        assert len(applied["applied"]) == queue["counts"]["items"]
+        summary = workspace.export_reading_session_summary(session["session_id"])
+        assert summary["progress"]["queued"] == queue["counts"]["items"]
+        assert summary["progress"]["total_checkpoints"] == queue["counts"]["items"]
+        assert summary["next_actions"] == ["continue_queued_targets"]
+        checkpoint = summary["blocked_targets"]
+        assert checkpoint == []
+    finally:
+        workspace.close()
+
+
+def test_apply_reading_queue_rejects_cross_paper_session(tmp_path: Path):
+    workspace_path, result_id = import_queue_pdf(tmp_path)
+    workspace = Workspace.open(workspace_path)
+    try:
+        other_pdf = tmp_path / "other.pdf"
+        write_queue_pdf(other_pdf)
+        workspace.import_pdf(other_pdf, "local:other")
+        queue = workspace.create_reading_queue(result_id)
+        other_session = workspace.create_reading_session("local:other")
+
+        with pytest.raises(ValueError, match="does not belong to the same paper"):
+            workspace.apply_reading_queue_to_session(
+                queue["queue_id"],
+                other_session["session_id"],
+            )
+    finally:
+        workspace.close()

--- a/tests/test_workspace_reading_queue_server.py
+++ b/tests/test_workspace_reading_queue_server.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import fitz
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+
+import papergraph.server as server
+
+
+def write_queue_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    server._reset_server_state()
+    yield
+    server._reset_server_state()
+
+
+def test_reading_queue_mcp_tools_return_payloads(tmp_path: Path):
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_queue_pdf(pdf)
+
+    server.open_workspace(str(workspace_path))
+    server.workspace_add_pdf_paper(str(pdf), "local:paper")
+
+    queue = server.workspace_create_reading_queue(
+        "local:paper::pdf:theorem:1.1",
+        label="Main theorem queue",
+    )
+    session = server.workspace_create_reading_session(
+        "local:paper",
+        target_result_id="local:paper::pdf:theorem:1.1",
+    )
+    applied = server.workspace_apply_reading_queue_to_session(
+        queue["queue_id"],
+        session["session_id"],
+    )
+    full = server.workspace_get_reading_queue(queue["queue_id"])
+
+    assert server.workspace_list_reading_queues()[0]["queue_id"] == queue["queue_id"]
+    assert full["queue"]["counts"]["items"] == 5
+    assert full["items"][0]["target_kind"] == "result_id"
+    assert applied["queue"]["queue_id"] == queue["queue_id"]
+    assert len(applied["applied"]) == 5
+
+
+def test_reading_queue_mcp_tools_report_missing_workspace():
+    with pytest.raises(ToolError, match="open_workspace"):
+        server.workspace_create_reading_queue("local:paper::pdf:theorem:1.1")
+
+
+def test_reading_queue_mcp_tools_convert_workspace_errors(tmp_path: Path):
+    server.open_workspace(str(tmp_path / "workspace.sqlite3"))
+
+    with pytest.raises(ToolError, match="Unknown reading queue id"):
+        server.workspace_get_reading_queue("queue:missing")

--- a/tests/test_workspace_reading_sessions.py
+++ b/tests/test_workspace_reading_sessions.py
@@ -37,7 +37,7 @@ def import_session_pdf(tmp_path: Path) -> tuple[Path, str]:
 def test_schema_v4_initializes_reading_session_tables(tmp_path: Path):
     workspace = Workspace.open(tmp_path / "workspace.sqlite3")
     try:
-        assert SCHEMA_VERSION == 4
+        assert SCHEMA_VERSION == 5
         tables = {
             row[0]
             for row in workspace._connection.execute(
@@ -51,7 +51,7 @@ def test_schema_v4_initializes_reading_session_tables(tmp_path: Path):
         } <= tables
         assert workspace._connection.execute(
             "SELECT value FROM workspace_meta WHERE key = 'schema_version'"
-        ).fetchone() == ("4",)
+        ).fetchone() == ("5",)
     finally:
         workspace.close()
 
@@ -59,6 +59,8 @@ def test_schema_v4_initializes_reading_session_tables(tmp_path: Path):
 def test_v3_workspace_migrates_to_v4_without_losing_evidence(tmp_path: Path):
     workspace_path, result_id = import_session_pdf(tmp_path)
     with sqlite3.connect(workspace_path) as connection:
+        connection.execute("DROP TABLE reading_queue_items")
+        connection.execute("DROP TABLE reading_queues")
         connection.execute("DROP TABLE reading_notes")
         connection.execute("DROP TABLE reading_checkpoints")
         connection.execute("DROP TABLE reading_sessions")
@@ -70,7 +72,7 @@ def test_v3_workspace_migrates_to_v4_without_losing_evidence(tmp_path: Path):
     try:
         assert workspace._connection.execute(
             "SELECT value FROM workspace_meta WHERE key = 'schema_version'"
-        ).fetchone() == ("4",)
+        ).fetchone() == ("5",)
         assert workspace.get_result(result_id)["result_id"] == result_id
         assert workspace.list_reading_sessions() == []
     finally:

--- a/tests/test_workspace_server.py
+++ b/tests/test_workspace_server.py
@@ -60,7 +60,7 @@ def test_open_workspace_returns_exact_payload(tmp_path: Path):
 
     assert server.open_workspace(str(database)) == {
         "path": str(database.resolve()),
-        "schema_version": 4,
+        "schema_version": 5,
         "papers": 0,
         "theorems": 0,
     }
@@ -166,10 +166,10 @@ def test_failed_workspace_open_preserves_active_workspace(tmp_path: Path):
             "CREATE TABLE workspace_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
         )
         connection.execute(
-            "INSERT INTO workspace_meta VALUES ('schema_version', '5')"
+            "INSERT INTO workspace_meta VALUES ('schema_version', '6')"
         )
 
-    with pytest.raises(ToolError, match="schema version 5"):
+    with pytest.raises(ToolError, match="schema version 6"):
         server.open_workspace(str(future))
 
     assert server.workspace_list_papers() == []

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add schema v5 Reading Queue Planner tables and workspace APIs
- generate deterministic required/recommended/caution queue items from reading path evidence
- apply queue items to v0.7 reading sessions as checkpoints
- expose MCP and JSON CLI queue commands
- prepare v0.8.0 docs and release pins

## Testing
- `uv run pytest` with `TMP`/`TEMP` set to the worktree `.tmp`
- Result: `399 passed, 1 skipped in 37.60s`