### PR TITLE
Add External Import Planner for v0.9.0

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -47,23 +47,23 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.8.0`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.9.0`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version
 ```
 
 The expected output is:
 
 ```text
-papergraph-mcp 0.8.0
+papergraph-mcp 0.9.0
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.8.0"
+      placeholder: "0.9.0"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.8.0"
+          test "$version" = "papergraph-mcp 0.9.0"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/lotchuazzz-crypto/papergraph-mcp)](https://github.com/lotchuazzz-crypto/papergraph-mcp/releases)
 
-PaperGraph turns local or arXiv LaTeX papers and born-digital PDFs into evidence-first theorem, result, proof, reading-session, and reading-queue state that AI agents can query through MCP. PaperGraph v0.8.0 adds a persistent Reading Queue Planner so agents can turn local proof-dependency paths into required, recommended, and caution reading targets, then apply those targets to resumable reading sessions.
+PaperGraph turns local or arXiv LaTeX papers and born-digital PDFs into evidence-first theorem, result, proof, reading-session, reading-queue, and external-import planning state that AI agents can query through MCP. PaperGraph v0.9.0 adds an External Import Planner so agents can turn external proof stops and citation evidence into a deterministic list of arXiv papers to import next.
+
+PaperGraph v0.8.0 added a persistent Reading Queue Planner so agents can turn local proof-dependency paths into required, recommended, and caution reading targets, then apply those targets to resumable reading sessions.
 
 PaperGraph v0.7.0 added persistent Reading Session State so agents can resume which evidence targets were reviewed, blocked, queued, or left as open questions.
 
@@ -28,6 +30,7 @@ Single-paper tools expose theorem-like environments, labels, and `\ref` relation
 - Export reading bridge bundles, result contexts, source slices, and reading paths for explanation-focused consumers.
 - Persist reading sessions, checkpoints, notes, open questions, and recovery summaries in the local workspace.
 - Plan deterministic reading queues from proof-dependency evidence and apply them to reading sessions.
+- Plan external arXiv imports from reading-path stops, reading queues, or paper-level citation evidence.
 - Keep theorem, reference, and citation records in a local SQLite workspace.
 - Search theorem titles and bodies across papers, with stable global IDs.
 - Traverse direct or recursive theorem dependencies and inspect incoming or outgoing citation evidence, including unresolved citations.
@@ -61,11 +64,11 @@ the decision without loading, call `validate_arxiv_request` or
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the GitHub release without cloning the repository:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
-The pinned command becomes available after the `v0.8.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.9.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 To validate a raw arXiv request before loading a paper, run:
 
@@ -82,7 +85,7 @@ For an MCP client that accepts JSON-style stdio server configuration, add:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0", "papergraph-mcp"]
     }
   }
 }
@@ -94,7 +97,7 @@ Restart the MCP client after changing its configuration. The server uses stdio, 
 
 The original single-paper tools remain available: `get_environment_diagnostics`, `validate_arxiv_request`, `load_arxiv_request`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`. Their signatures are `get_environment_diagnostics()`, `validate_arxiv_request(input: str)`, `load_arxiv_request(input: str, main_file: str | None = None, refresh: bool = False)`, `validate_arxiv_input(text_id: str | None = None, url: str | None = None)`, `load_paper(path: str)`, `load_arxiv_paper(arxiv_id: str, main_file: str | None = None, refresh: bool = False)`, `list_theorems(kind: str | None = None)`, `get_theorem(theorem_id: str)`, `get_dependencies(theorem_id: str, recursive: bool = False)`, `get_dependency_diagnostics(theorem_id: str, recursive: bool = False)`, and `where_used(theorem_id: str)`.
 
-Workspace tools operate on the active database. Call `open_workspace` first: `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_add_pdf_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary`, `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, and `workspace_apply_reading_queue_to_session` require that active workspace. Their exact MCP signatures and return summaries are:
+Workspace tools operate on the active database. Call `open_workspace` first: `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_add_pdf_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary`, `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, `workspace_apply_reading_queue_to_session`, `workspace_plan_external_imports_for_result`, `workspace_plan_external_imports_for_queue`, and `workspace_plan_external_imports_for_paper` require that active workspace. Their exact MCP signatures and return summaries are:
 
 | Tool signature | Returns |
 | --- | --- |
@@ -129,6 +132,9 @@ Workspace tools operate on the active database. Call `open_workspace` first: `wo
 | `workspace_list_reading_queues(paper_id: str | None = None, status: str | None = None) -> list[dict]` | Lists queues ordered for resumption, optionally filtered by paper or active/archived status. |
 | `workspace_get_reading_queue(queue_id: str) -> dict` | Returns one queue with deterministic required, recommended, and caution item ordering. |
 | `workspace_apply_reading_queue_to_session(queue_id: str, session_id: str, status: str = "queued") -> dict` | Applies queue items as reading-session checkpoints with queue provenance. |
+| `workspace_plan_external_imports_for_result(result_id: str, recursive: bool = True) -> dict` | Plans external arXiv imports from one result's reading path, preserving blocked stops without arXiv IDs. |
+| `workspace_plan_external_imports_for_queue(queue_id: str) -> dict` | Plans external arXiv imports from saved reading queue caution items. |
+| `workspace_plan_external_imports_for_paper(paper_id: str) -> dict` | Plans external arXiv imports from paper-level citation and external mention evidence. |
 
 For a compact single-paper check with an already-disambiguated ID, call `load_arxiv_paper(arxiv_id="math/0307200")`. For ordinary user text, call `load_arxiv_request(input="math/0307200")`. PaperGraph selects `main.tex`; a representative first response has `"path": "main.tex"`, `"cached": false`, and `"nodes": 7`.
 
@@ -232,6 +238,29 @@ papergraph-mcp apply-reading-queue-to-session --workspace C:/Temp/papergraph-rea
 ```
 
 Reading queues do not verify proofs or generate theorem explanations. They preserve the evidence-derived order and stop reasons so a reading agent can inspect, explain, or defer each target without silently inventing missing dependencies.
+
+## External import planner workflow
+
+Use the External Import Planner when a reading path or queue reaches external stops and the next question is which cited arXiv papers should be imported into the workspace. The planner is read-only: it groups stored external mentions, citation mentions, and bibliography entries into `import_candidate` or `already_imported` arXiv candidates, and keeps non-actionable evidence in `blocked`.
+
+```text
+open_workspace(path="C:/Temp/papergraph-reading.sqlite3")
+workspace_plan_external_imports_for_result(result_id="local:example::pdf:theorem:1.1")
+workspace_create_reading_queue(result_id="local:example::pdf:theorem:1.1")
+workspace_plan_external_imports_for_queue(queue_id="queue:...")
+workspace_plan_external_imports_for_paper(paper_id="local:example")
+```
+
+The same planner can be used from a shell against an existing workspace:
+
+```powershell
+papergraph-mcp plan-external-imports-for-result --workspace C:/Temp/papergraph-reading.sqlite3 --result-id local:example::pdf:theorem:1.1
+papergraph-mcp plan-external-imports-for-result --workspace C:/Temp/papergraph-reading.sqlite3 --result-id local:example::pdf:theorem:1.1 --direct
+papergraph-mcp plan-external-imports-for-queue --workspace C:/Temp/papergraph-reading.sqlite3 --queue-id queue:...
+papergraph-mcp plan-external-imports-for-paper --workspace C:/Temp/papergraph-reading.sqlite3 --paper-id local:example
+```
+
+External import plans do not download papers, call live arXiv, resolve DOI-only references, or match external theorem numbers to local theorem statements. They only make the next import decision auditable.
 
 ## Three-paper local walkthrough
 

--- a/docs/superpowers/plans/2026-09-08-external-import-planner-v0.9.md
+++ b/docs/superpowers/plans/2026-09-08-external-import-planner-v0.9.md
@@ -1,0 +1,432 @@
+# External Import Planner v0.9 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build read-only external import planning for result, queue, and paper scopes.
+
+**Architecture:** Add deterministic planner methods to `Workspace` without changing the SQLite schema. Reuse existing reading path, reading queue, citation evidence, bibliography entries, and external result mention records; expose the planner through MCP wrappers and JSON CLI commands.
+
+**Tech Stack:** Python 3.10+, SQLite, existing MCP server wrapper, pytest, existing JSON CLI conventions.
+
+## Global Constraints
+
+- No subagents for this implementation.
+- Release version is `0.9.0`.
+- Planning must be read-only and must not download papers or call live arXiv.
+- Plans use only stored workspace evidence.
+- Output order must be deterministic.
+- CLI output must be one JSON payload on success.
+- Existing v0.8 reading session and reading queue APIs remain compatible.
+
+---
+
+## File Structure
+
+- Modify `src/papergraph/workspace.py`: planner APIs, evidence collection helpers, candidate grouping helpers.
+- Modify `src/papergraph/server.py`: MCP wrappers and argparse commands.
+- Add `tests/test_workspace_external_import_planner.py`: workspace behavior tests.
+- Add `tests/test_workspace_external_import_planner_server.py`: MCP wrapper tests.
+- Add `tests/test_cli_external_import_planner.py`: CLI tests.
+- Modify `README.md`: document v0.9.0 and workflow.
+- Modify `pyproject.toml`, `uv.lock`, `.github/workflows/ci.yml`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `src/papergraph/arxiv.py`, `scripts/check_onboarding.py`, `.agents/skills/setting-up-papergraph/SKILL.md`, `.agents/skills/setting-up-papergraph/references/client-configuration.md`: release pins.
+- Modify existing repository/onboarding/diagnostics tests for v0.9.0 and new tool names.
+
+---
+
+### Task 1: Workspace Planner
+
+**Files:**
+- Modify: `src/papergraph/workspace.py`
+- Test: `tests/test_workspace_external_import_planner.py`
+
+**Interfaces:**
+- Consumes: `get_result_reading_path(result_id, recursive)`, `get_reading_queue(queue_id)`, `list_results(paper_id)`, `get_proof_dependencies(result_id)`, `get_citations(paper_id, direction, include_unresolved)`.
+- Produces:
+  - `Workspace.plan_external_imports_for_result(result_id: str, recursive: bool = True) -> dict`
+  - `Workspace.plan_external_imports_for_queue(queue_id: str) -> dict`
+  - `Workspace.plan_external_imports_for_paper(paper_id: str) -> dict`
+
+- [ ] **Step 1: Write failing workspace tests**
+
+Create `tests/test_workspace_external_import_planner.py` with tests that:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from papergraph.workspace import Workspace
+
+
+def write_pdf_fixture(path: Path) -> None:
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+
+    pdf = canvas.Canvas(str(path), pagesize=letter)
+    pdf.drawString(72, 720, "Lemma 1.2. Local bootstrap lemma.")
+    pdf.drawString(72, 700, "Proof. This is local.")
+    pdf.drawString(72, 660, "Theorem 1.1. Main theorem.")
+    pdf.drawString(
+        72,
+        640,
+        "Proof. By Lemma 1.2, Lemma 9.9, and [12, Theorem 3.5], the claim follows.",
+    )
+    pdf.drawString(72, 600, "References")
+    pdf.drawString(72, 580, "[12] A. Author, arXiv:2401.12345v2.")
+    pdf.save()
+
+
+def import_fixture(workspace: Workspace, tmp_path: Path) -> str:
+    pdf = tmp_path / "paper.pdf"
+    write_pdf_fixture(pdf)
+    workspace.import_pdf(pdf, "local:paper")
+    return "local:paper::pdf:theorem:1.1"
+
+
+def test_result_plan_groups_external_mentions_by_arxiv(tmp_path: Path):
+    with Workspace.open(tmp_path / "workspace.sqlite3") as workspace:
+        result_id = import_fixture(workspace, tmp_path)
+
+        plan = workspace.plan_external_imports_for_result(result_id)
+
+        assert plan["plan_schema_version"] == 1
+        assert plan["scope"]["kind"] == "result_id"
+        assert plan["summary"]["candidate_count"] == 1
+        assert plan["summary"]["import_candidate_count"] == 1
+        candidate = plan["candidates"][0]
+        assert candidate["candidate_id"] == "external-import:arxiv:2401.12345"
+        assert candidate["status"] == "import_candidate"
+        assert candidate["source"]["recommended_paper_id"] == "arxiv:2401.12345"
+        assert candidate["source"]["arxiv_version"] == "v2"
+        assert {item["kind"] for item in candidate["evidence"]} >= {
+            "external_result_mention",
+            "citation_mention",
+            "bibliography_entry",
+        }
+        assert plan["summary"]["blocked_count"] == 1
+        assert plan["blocked"][0]["reason"] == "missing_arxiv_id"
+
+
+def test_result_plan_marks_imported_arxiv_candidates(tmp_path: Path):
+    with Workspace.open(tmp_path / "workspace.sqlite3") as workspace:
+        result_id = import_fixture(workspace, tmp_path)
+        target = tmp_path / "target.tex"
+        target.write_text(
+            r"\\documentclass{article}\\newtheorem{theorem}{Theorem}\\begin{document}\\begin{theorem}\\label{t}Imported.\\end{theorem}\\end{document}",
+            encoding="utf-8",
+        )
+        workspace.import_paper(target, "arxiv", "2401.12345")
+
+        candidate = workspace.plan_external_imports_for_result(result_id)["candidates"][0]
+
+        assert candidate["status"] == "already_imported"
+        assert candidate["source"]["recommended_paper_id"] == "arxiv:2401.12345"
+
+
+def test_queue_plan_uses_saved_queue_caution_items(tmp_path: Path):
+    with Workspace.open(tmp_path / "workspace.sqlite3") as workspace:
+        result_id = import_fixture(workspace, tmp_path)
+        queue = workspace.create_reading_queue(result_id)
+
+        plan = workspace.plan_external_imports_for_queue(queue["queue_id"])
+
+        assert plan["scope"]["kind"] == "queue_id"
+        assert plan["summary"]["candidate_count"] == 1
+        assert plan["summary"]["blocked_count"] == 1
+        assert all(
+            evidence["source"].startswith("reading_queue")
+            or evidence["source"].startswith("result")
+            for candidate in plan["candidates"]
+            for evidence in candidate["evidence"]
+        )
+
+
+def test_paper_plan_includes_citation_evidence_without_queue(tmp_path: Path):
+    with Workspace.open(tmp_path / "workspace.sqlite3") as workspace:
+        import_fixture(workspace, tmp_path)
+
+        plan = workspace.plan_external_imports_for_paper("local:paper")
+
+        assert plan["scope"] == {
+            "kind": "paper_id",
+            "value": "local:paper",
+            "paper_id": "local:paper",
+            "recursive": None,
+        }
+        assert plan["candidates"][0]["source"]["arxiv_id"] == "2401.12345"
+
+
+def test_plan_rejects_non_boolean_recursive(tmp_path: Path):
+    with Workspace.open(tmp_path / "workspace.sqlite3") as workspace:
+        result_id = import_fixture(workspace, tmp_path)
+
+        with pytest.raises(ValueError, match="recursive must be a boolean"):
+            workspace.plan_external_imports_for_result(result_id, recursive="yes")
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_workspace_external_import_planner.py -v
+```
+
+Expected: fail because planner methods are not defined.
+
+- [ ] **Step 3: Implement planner methods and helpers**
+
+Add methods in `Workspace` near reading queue APIs:
+
+```python
+@_synchronized
+def plan_external_imports_for_result(self, result_id: str, recursive: bool = True) -> dict:
+    if not isinstance(recursive, bool):
+        raise ValueError("recursive must be a boolean")
+    result = self.get_result(result_id)
+    collector = _ExternalImportPlanCollector(self)
+    path = self.get_result_reading_path(result_id, recursive=recursive)
+    for mention in path["external_stops"]:
+        collector.add_external_mention(mention["mention_id"], "reading_path.external_stops")
+    for stop in path["unresolved_stops"]:
+        collector.add_blocked(
+            "missing_arxiv_id",
+            [
+                {
+                    "kind": "unresolved_stop",
+                    "id": f"{stop['result_id']}:{stop['kind']}",
+                    "paper_id": result["paper_id"],
+                    "result_id": stop["result_id"],
+                    "proof_id": None,
+                    "citation_key": None,
+                    "raw_text": stop["kind"],
+                    "source": "reading_path.unresolved_stops",
+                }
+            ],
+        )
+    return collector.payload(
+        {
+            "kind": "result_id",
+            "value": result_id,
+            "paper_id": result["paper_id"],
+            "recursive": recursive,
+        }
+    )
+```
+
+Implement analogous queue and paper methods, plus a private collector that:
+
+- fetches `external_result_mentions`, `citation_mentions`, and `bibliography_entries` rows by ID
+- groups candidates by bibliography/citation arXiv ID
+- checks `self._connection.execute("SELECT 1 FROM papers WHERE paper_id = ?", (f"arxiv:{arxiv_id}",))`
+- emits stable IDs and sorted payloads
+
+- [ ] **Step 4: Run workspace tests to verify green**
+
+Run the same test command. Expected: all planner workspace tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/workspace.py tests/test_workspace_external_import_planner.py
+git commit -m "feat: add external import planning workspace api"
+```
+
+---
+
+### Task 2: MCP and CLI Exposure
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Test: `tests/test_workspace_external_import_planner_server.py`
+- Test: `tests/test_cli_external_import_planner.py`
+
+**Interfaces:**
+- Consumes:
+  - `Workspace.plan_external_imports_for_result(result_id, recursive=True)`
+  - `Workspace.plan_external_imports_for_queue(queue_id)`
+  - `Workspace.plan_external_imports_for_paper(paper_id)`
+- Produces:
+  - MCP wrappers `workspace_plan_external_imports_for_result`, `workspace_plan_external_imports_for_queue`, `workspace_plan_external_imports_for_paper`
+  - CLI commands `plan-external-imports-for-result`, `plan-external-imports-for-queue`, `plan-external-imports-for-paper`
+
+- [ ] **Step 1: Write failing MCP and CLI tests**
+
+Create server tests that open a workspace, import the PDF fixture from Task 1, call the wrappers, and assert candidate counts. Also test missing workspace and unknown IDs produce `ToolError`.
+
+Create CLI tests that run `server.main([...])` with the new commands and assert JSON output.
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_external_import_planner_server.py tests/test_cli_external_import_planner.py -v
+```
+
+Expected: fail because wrappers and commands are not defined.
+
+- [ ] **Step 3: Add MCP wrappers**
+
+Add wrappers in `src/papergraph/server.py` next to reading queue tools. Follow the existing `_serialized_workspace_tool` and `_WORKSPACE_TOOL_ERRORS` pattern.
+
+- [ ] **Step 4: Add CLI parsers and handlers**
+
+Add argparse subcommands near reading queue commands, with `--direct` for result planning. Use `_run_workspace_cli_command` and `_print_json`.
+
+- [ ] **Step 5: Run MCP/CLI tests to verify green**
+
+Run the same focused command. Expected: all new MCP/CLI tests pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_workspace_external_import_planner_server.py tests/test_cli_external_import_planner.py
+git commit -m "feat: expose external import planner tools"
+```
+
+---
+
+### Task 3: v0.9 Documentation and Release Pins
+
+**Files:**
+- Modify: `README.md`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `scripts/check_onboarding.py`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_diagnostics.py`
+- Modify: `tests/test_server.py`
+
+**Interfaces:**
+- Consumes: new MCP and CLI names from Task 2.
+- Produces: release-ready `0.9.0` docs and tests.
+
+- [ ] **Step 1: Update tests first**
+
+Update repository/onboarding/diagnostics tests from v0.8.0 to v0.9.0 and add README expectations for:
+
+```text
+workspace_plan_external_imports_for_result
+workspace_plan_external_imports_for_queue
+workspace_plan_external_imports_for_paper
+plan-external-imports-for-result
+plan-external-imports-for-queue
+plan-external-imports-for-paper
+```
+
+- [ ] **Step 2: Run docs tests to verify red**
+
+Run:
+
+```powershell
+uv run pytest tests/test_repository.py tests/test_onboarding.py tests/test_cli.py tests/test_diagnostics.py tests/test_server.py -v
+```
+
+Expected: fail until docs and pins are updated.
+
+- [ ] **Step 3: Update docs and version pins**
+
+Update:
+
+- package version to `0.9.0`
+- pinned install commands to `v0.9.0`
+- user agent to `PaperGraph/0.9.0`
+- CI smoke expected output to `papergraph-mcp 0.9.0`
+- README feature list and tool table
+- README External Import Planner workflow
+
+- [ ] **Step 4: Run docs tests to verify green**
+
+Run the same docs test command. Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add README.md pyproject.toml uv.lock .github/workflows/ci.yml .github/ISSUE_TEMPLATE/bug_report.yml src/papergraph/arxiv.py scripts/check_onboarding.py .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/client-configuration.md tests/test_repository.py tests/test_onboarding.py tests/test_cli.py tests/test_diagnostics.py tests/test_server.py
+git commit -m "docs: prepare v0.9.0 release"
+```
+
+---
+
+### Task 4: Final Verification, PR, and Release
+
+**Files:**
+- No code files expected unless verification exposes a bug.
+
+**Interfaces:**
+- Consumes: complete branch from Tasks 1-3.
+- Produces: PR, merge to main, `v0.9.0` tag, GitHub Release.
+
+- [ ] **Step 1: Run full local verification**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest
+```
+
+Expected: all tests pass with one skipped.
+
+- [ ] **Step 2: Self-review branch state**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --oneline --decorate --max-count=12
+rg -n 'papergraph-mcp\.git@v0\.8\.0|papergraph-mcp 0\.8\.0|PaperGraph/0\.8\.0|version = "0\.8\.0"' README.md pyproject.toml uv.lock .github scripts src tests .agents/skills/setting-up-papergraph
+```
+
+Expected: clean worktree and no active v0.8 install pins outside historical README text.
+
+- [ ] **Step 3: Push and create PR**
+
+Run:
+
+```powershell
+git push -u origin feature/v0.9-external-import-planner
+```
+
+Create a PR from `feature/v0.9-external-import-planner` to `main` titled `Add External Import Planner for v0.9.0`.
+
+- [ ] **Step 4: Wait for PR CI**
+
+Wait for GitHub Actions CI on the PR head SHA. Expected: success.
+
+- [ ] **Step 5: Merge PR**
+
+Squash merge after PR CI passes.
+
+- [ ] **Step 6: Wait for main CI**
+
+Fetch `origin/main`, confirm merge commit, and wait for push CI on main. Expected: success.
+
+- [ ] **Step 7: Tag and verify pinned install**
+
+Create and push:
+
+```powershell
+git tag -a v0.9.0 <main-merge-sha> -m "PaperGraph MCP v0.9.0"
+git push origin v0.9.0
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version
+```
+
+Expected: `papergraph-mcp 0.9.0`.
+
+- [ ] **Step 8: Create GitHub Release**
+
+Create GitHub Release `PaperGraph MCP v0.9.0` on tag `v0.9.0` with highlights and verification evidence.

--- a/docs/superpowers/specs/2026-09-08-external-import-planner-v0.9-design.md
+++ b/docs/superpowers/specs/2026-09-08-external-import-planner-v0.9-design.md
@@ -1,0 +1,261 @@
+# External Import Planner v0.9 Design
+
+## Goal
+
+PaperGraph v0.9 adds an evidence-first External Import Planner. Given a result, reading queue, or whole paper, PaperGraph will collect external and unresolved reading stops, group them into deterministic import candidates, and report which arXiv papers should be imported next, which references are already locally covered, and which stops remain non-actionable.
+
+The planner does not download papers, resolve theorem equivalence, or verify proofs. It produces a reviewable import plan that a reading agent can inspect before calling existing import tools.
+
+## Context
+
+PaperGraph v0.8 can build reading queues from local proof-dependency paths. Queue items classify the selected result and proof as `required`, local dependencies as `recommended`, and external or unresolved stops as `caution`.
+
+The next gap is that a `caution` item often points to a bibliography-backed external theorem mention such as `[12, Theorem 3.5]`. The workspace already stores citation mentions, bibliography entries, arXiv identifiers, external result mentions, and source spans. v0.9 should turn that evidence into an ordered next-import plan without inventing missing metadata.
+
+## Users
+
+- A paper-reading agent that wants to continue after a reading path reaches external stops.
+- A human or agent maintaining a local workspace and deciding which cited papers to import next.
+- A CI or terminal workflow that wants a JSON report before mutating the workspace.
+
+## Scope
+
+### In Scope
+
+- Generate import plans from:
+  - `result_id`
+  - `queue_id`
+  - `paper_id`
+- Include only evidence already stored in the workspace.
+- Group actionable external mentions and citation evidence by normalized arXiv paper ID.
+- Mark candidates already present in the workspace as `already_imported`.
+- Mark candidates with arXiv IDs not yet imported as `import_candidate`.
+- Preserve non-actionable evidence as `blocked` items when no arXiv ID is known.
+- Include source evidence:
+  - external result mention IDs
+  - citation mention IDs
+  - bibliography entry IDs
+  - raw text / citation key / result context where available
+- Expose MCP tools and CLI commands for create/list/get/apply-style read-only planning.
+- Update README, diagnostics/release pins, and onboarding pins for v0.9.0.
+
+### Out of Scope
+
+- Automatically importing arXiv papers.
+- Calling the live arXiv API while planning.
+- DOI, Crossref, Semantic Scholar, or web search resolution.
+- Theorem-level matching between a local result and an external theorem mention.
+- Persistent schema changes. Plans can be recomputed deterministically from stored evidence.
+- Removing or deprecating existing CLI commands.
+
+## Public API
+
+### Workspace Python API
+
+Add these methods to `Workspace`:
+
+```python
+def plan_external_imports_for_result(
+    self,
+    result_id: str,
+    recursive: bool = True,
+) -> dict: ...
+
+def plan_external_imports_for_queue(
+    self,
+    queue_id: str,
+) -> dict: ...
+
+def plan_external_imports_for_paper(
+    self,
+    paper_id: str,
+) -> dict: ...
+```
+
+All three return the same payload shape:
+
+```python
+{
+    "plan_schema_version": 1,
+    "scope": {
+        "kind": "result_id" | "queue_id" | "paper_id",
+        "value": "...",
+        "paper_id": "...",
+        "recursive": True | False | None,
+    },
+    "candidates": [
+        {
+            "candidate_id": "external-import:arxiv:2401.12345",
+            "status": "import_candidate" | "already_imported",
+            "source": {
+                "type": "arxiv",
+                "arxiv_id": "2401.12345",
+                "arxiv_version": "v2" | None,
+                "recommended_paper_id": "arxiv:2401.12345",
+            },
+            "evidence": [...],
+            "counts": {
+                "external_mentions": 1,
+                "citation_mentions": 1,
+                "bibliography_entries": 1,
+            },
+        },
+    ],
+    "blocked": [
+        {
+            "blocked_id": "external-import:blocked:<stable-slug>",
+            "reason": "missing_arxiv_id",
+            "evidence": [...],
+        },
+    ],
+    "summary": {
+        "candidate_count": 1,
+        "import_candidate_count": 1,
+        "already_imported_count": 0,
+        "blocked_count": 1,
+    },
+    "warnings": [],
+}
+```
+
+### MCP Tools
+
+Add:
+
+- `workspace_plan_external_imports_for_result(result_id: str, recursive: bool = True) -> dict`
+- `workspace_plan_external_imports_for_queue(queue_id: str) -> dict`
+- `workspace_plan_external_imports_for_paper(paper_id: str) -> dict`
+
+These tools require an active workspace. They convert workspace validation errors into MCP `ToolError`, following existing workspace tool patterns.
+
+### CLI Commands
+
+Add JSON-only commands:
+
+```powershell
+papergraph-mcp plan-external-imports-for-result --workspace C:/Temp/papergraph.sqlite3 --result-id local:paper::pdf:theorem:1.1
+papergraph-mcp plan-external-imports-for-result --workspace C:/Temp/papergraph.sqlite3 --result-id local:paper::pdf:theorem:1.1 --direct
+papergraph-mcp plan-external-imports-for-queue --workspace C:/Temp/papergraph.sqlite3 --queue-id queue:...
+papergraph-mcp plan-external-imports-for-paper --workspace C:/Temp/papergraph.sqlite3 --paper-id local:paper
+```
+
+`--direct` means `recursive=False`, matching the existing reading path and reading queue conventions.
+
+## Evidence Model
+
+### Candidate Evidence Records
+
+Every evidence record has a deterministic shape:
+
+```python
+{
+    "kind": "external_result_mention" | "citation_mention" | "bibliography_entry",
+    "id": "...",
+    "paper_id": "...",
+    "result_id": "..." | None,
+    "proof_id": "..." | None,
+    "citation_key": "..." | None,
+    "raw_text": "..." | None,
+    "source": "reading_path.external_stops" | "reading_queue.external_stop" | "paper.citation_evidence",
+}
+```
+
+When an external result mention references a citation mention or bibliography entry, the planner follows those stored IDs to gather arXiv metadata. If no arXiv ID exists, the original mention remains in `blocked`.
+
+### Candidate Grouping
+
+The planner groups by normalized arXiv ID only. Different versions of the same arXiv ID become one candidate. If multiple versions appear, the candidate records:
+
+- `arxiv_version`: the highest evidence version by stable string order when present, otherwise `None`.
+- `evidence`: all contributing evidence records in deterministic order.
+- `warnings`: include `conflicting_versions` only when two or more distinct non-null versions appear.
+
+The recommended paper ID is always `arxiv:<arxiv_id>`.
+
+### Already Imported
+
+A candidate is `already_imported` when a workspace paper exists with `paper_id == "arxiv:<arxiv_id>"`. It remains in the candidate list because it is still useful evidence, but its status prevents agents from importing it again.
+
+### Blocked Items
+
+Blocked items preserve stops without an arXiv ID:
+
+- bibliography entry with DOI or URL but no arXiv ID
+- citation mention with missing bibliography entry
+- external result mention without traceable bibliography metadata
+- unresolved reading path stop such as unresolved local theorem references
+
+Blocked items should carry enough evidence for a reading agent to ask a human, search manually, or decide that the stop is not importable.
+
+## Data Flow
+
+### Result Scope
+
+1. Validate `result_id`.
+2. Compute `get_result_reading_path(result_id, recursive=recursive)`.
+3. Collect `external_stops`.
+4. Collect `unresolved_stops` into blocked items.
+5. For each local result in `top_down`, inspect proof dependencies to gather citation and external mention evidence.
+6. Resolve evidence into arXiv candidates or blocked items.
+
+### Queue Scope
+
+1. Validate `queue_id`.
+2. Read queue items.
+3. For `external_stop` items, resolve the referenced external mention.
+4. For `unresolved_stop` items, carry item evidence into blocked items.
+5. For `result_id` items, inspect that result's direct proof dependencies so queue plans remain bounded by queue contents rather than recursively expanding beyond the saved queue.
+
+### Paper Scope
+
+1. Validate `paper_id`.
+2. Inspect all stored citation evidence rows for the paper.
+3. Inspect all external result mentions for the paper.
+4. Resolve evidence into candidates or blocked items.
+5. Paper scope does not compute recursive reading paths.
+
+## Determinism
+
+Output order is stable:
+
+1. candidates sorted by status (`import_candidate` before `already_imported`), arXiv ID, then candidate ID
+2. evidence within candidates sorted by kind, ID
+3. blocked items sorted by reason, blocked ID
+
+Generated IDs use only stored IDs and normalized strings, never timestamps.
+
+## Error Handling
+
+- Unknown `result_id`, `queue_id`, or `paper_id` raises `KeyError`.
+- Invalid `recursive` type raises `ValueError`.
+- Plans with no candidates and no blocked items return an empty plan with zero counts.
+- MCP wrappers convert `KeyError`, `ValueError`, and workspace errors into `ToolError`.
+- CLI commands print one JSON payload on success and write one error message to stderr with exit code 1 on failure.
+
+## Tests
+
+Add focused tests for:
+
+- Result plan groups bibliography-backed external mentions into arXiv candidates.
+- Result plan includes unresolved reading stops as blocked items.
+- Already-imported arXiv papers change candidate status to `already_imported`.
+- Queue plan uses stored queue caution items and does not recursively expand beyond queue result items.
+- Paper plan includes citation evidence even without a reading queue.
+- MCP wrappers return payloads and convert workspace errors.
+- CLI commands print JSON and report unknown IDs.
+- README and repository tests expose v0.9.0 pins and the new tools.
+
+## Release
+
+Release as `v0.9.0`.
+
+Verification before PR:
+
+- `uv run pytest`
+- PR CI on Ubuntu and Windows, Python 3.10 and 3.12
+- main CI after merge
+- pinned install:
+
+```powershell
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.8.0"
+version = "0.9.0"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.8.0"
+PAPERGRAPH_VERSION = "0.9.0"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.8.0"
+    "papergraph-mcp.git@v0.9.0"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -26,7 +26,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.8.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.9.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -616,6 +616,45 @@ def workspace_apply_reading_queue_to_session(
 
 
 @mcp.tool()
+@_serialized_workspace_tool
+def workspace_plan_external_imports_for_result(
+    result_id: str,
+    recursive: bool = True,
+) -> dict:
+    """Plan external arXiv imports for one result's reading path."""
+
+    try:
+        return require_workspace().plan_external_imports_for_result(
+            result_id,
+            recursive=recursive,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
+@_serialized_workspace_tool
+def workspace_plan_external_imports_for_queue(queue_id: str) -> dict:
+    """Plan external arXiv imports referenced by one reading queue."""
+
+    try:
+        return require_workspace().plan_external_imports_for_queue(queue_id)
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
+@_serialized_workspace_tool
+def workspace_plan_external_imports_for_paper(paper_id: str) -> dict:
+    """Plan external arXiv imports visible in one stored paper."""
+
+    try:
+        return require_workspace().plan_external_imports_for_paper(paper_id)
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
 def load_paper(path: str) -> dict:
     """Load a local LaTeX paper and build its theorem graph."""
 
@@ -1018,6 +1057,29 @@ def main(argv: Sequence[str] | None = None) -> None:
     apply_queue_parser.add_argument("--queue-id", required=True)
     apply_queue_parser.add_argument("--session-id", required=True)
     apply_queue_parser.add_argument("--status", default="queued")
+    result_import_plan_parser = subparsers.add_parser(
+        "plan-external-imports-for-result",
+        help="Plan external arXiv imports for one result.",
+    )
+    result_import_plan_parser.add_argument("--workspace", required=True)
+    result_import_plan_parser.add_argument("--result-id", required=True)
+    result_import_plan_parser.add_argument(
+        "--direct",
+        action="store_true",
+        help="Plan only direct dependencies instead of recursive traversal.",
+    )
+    queue_import_plan_parser = subparsers.add_parser(
+        "plan-external-imports-for-queue",
+        help="Plan external arXiv imports referenced by one reading queue.",
+    )
+    queue_import_plan_parser.add_argument("--workspace", required=True)
+    queue_import_plan_parser.add_argument("--queue-id", required=True)
+    paper_import_plan_parser = subparsers.add_parser(
+        "plan-external-imports-for-paper",
+        help="Plan external arXiv imports visible in one stored paper.",
+    )
+    paper_import_plan_parser.add_argument("--workspace", required=True)
+    paper_import_plan_parser.add_argument("--paper-id", required=True)
 
     args = parser.parse_args(argv)
     if args.command == "doctor":
@@ -1195,6 +1257,34 @@ def main(argv: Sequence[str] | None = None) -> None:
                 args.queue_id,
                 args.session_id,
                 status=args.status,
+            ),
+        )
+        return
+    if args.command == "plan-external-imports-for-result":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.plan_external_imports_for_result(
+                args.result_id,
+                recursive=not args.direct,
+            ),
+        )
+        return
+    if args.command == "plan-external-imports-for-queue":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.plan_external_imports_for_queue(
+                args.queue_id,
+            ),
+        )
+        return
+    if args.command == "plan-external-imports-for-paper":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.plan_external_imports_for_paper(
+                args.paper_id,
             ),
         )
         return

--- a/src/papergraph/workspace.py
+++ b/src/papergraph/workspace.py
@@ -1789,13 +1789,14 @@ class Workspace:
                 "reading_path.external_stops",
             )
         for stop in path["unresolved_stops"]:
+            stop_result = self.get_result(stop["result_id"])
             collector.add_blocked(
                 "missing_arxiv_id",
                 [
                     {
                         "kind": "unresolved_stop",
                         "id": f"{stop['result_id']}:{stop['kind']}",
-                        "paper_id": result["paper_id"],
+                        "paper_id": stop_result["paper_id"],
                         "result_id": stop["result_id"],
                         "proof_id": None,
                         "citation_key": None,

--- a/src/papergraph/workspace.py
+++ b/src/papergraph/workspace.py
@@ -1770,6 +1770,130 @@ class Workspace:
         }
 
     @_synchronized
+    def plan_external_imports_for_result(
+        self,
+        result_id: str,
+        recursive: bool = True,
+    ) -> dict:
+        """Plan external arXiv imports needed by one result's reading path."""
+
+        if not isinstance(recursive, bool):
+            raise ValueError("recursive must be a boolean")
+        result = self.get_result(result_id)
+        collector = _ExternalImportPlanCollector(self)
+        path = self.get_result_reading_path(result_id, recursive=recursive)
+
+        for mention in path["external_stops"]:
+            collector.add_external_mention(
+                mention["mention_id"],
+                "reading_path.external_stops",
+            )
+        for stop in path["unresolved_stops"]:
+            collector.add_blocked(
+                "missing_arxiv_id",
+                [
+                    {
+                        "kind": "unresolved_stop",
+                        "id": f"{stop['result_id']}:{stop['kind']}",
+                        "paper_id": result["paper_id"],
+                        "result_id": stop["result_id"],
+                        "proof_id": None,
+                        "citation_key": None,
+                        "raw_text": stop["kind"],
+                        "source": "reading_path.unresolved_stops",
+                    }
+                ],
+            )
+
+        return collector.payload(
+            {
+                "kind": "result_id",
+                "value": result_id,
+                "paper_id": result["paper_id"],
+                "recursive": recursive,
+            }
+        )
+
+    @_synchronized
+    def plan_external_imports_for_queue(self, queue_id: str) -> dict:
+        """Plan external arXiv imports referenced by a saved reading queue."""
+
+        queue_payload = self._reading_queue_payload(queue_id)
+        collector = _ExternalImportPlanCollector(self)
+        for item in self._reading_queue_items(queue_id):
+            if item["target_kind"] == "external_stop":
+                collector.add_external_mention(
+                    item["target_id"],
+                    "reading_queue.external_stop",
+                )
+            elif item["target_kind"] == "unresolved_stop":
+                collector.add_blocked(
+                    "missing_arxiv_id",
+                    [
+                        {
+                            "kind": "unresolved_stop",
+                            "id": item["target_id"],
+                            "paper_id": queue_payload["paper_id"],
+                            "result_id": item["evidence"].get("result_id"),
+                            "proof_id": None,
+                            "citation_key": None,
+                            "raw_text": item["reason"],
+                            "source": "reading_queue.unresolved_stop",
+                        }
+                    ],
+                )
+
+        return collector.payload(
+            {
+                "kind": "queue_id",
+                "value": queue_id,
+                "paper_id": queue_payload["paper_id"],
+                "recursive": None,
+            }
+        )
+
+    @_synchronized
+    def plan_external_imports_for_paper(self, paper_id: str) -> dict:
+        """Plan external arXiv imports visible in one stored paper."""
+
+        normalized_paper_id = normalize_paper_id(paper_id)
+        self.get_paper(normalized_paper_id)
+        collector = _ExternalImportPlanCollector(self)
+
+        external_rows = self._connection.execute(
+            """
+            SELECT mention_id
+            FROM external_result_mentions
+            WHERE paper_id = ?
+            ORDER BY mention_id
+            """,
+            (normalized_paper_id,),
+        ).fetchall()
+        for row in external_rows:
+            collector.add_external_mention(row[0], "paper.external_result_mentions")
+
+        citation_rows = self._connection.execute(
+            """
+            SELECT mention_id
+            FROM citation_mentions
+            WHERE paper_id = ?
+            ORDER BY mention_id
+            """,
+            (normalized_paper_id,),
+        ).fetchall()
+        for row in citation_rows:
+            collector.add_citation_mention(row[0], "paper.citation_mentions")
+
+        return collector.payload(
+            {
+                "kind": "paper_id",
+                "value": normalized_paper_id,
+                "paper_id": normalized_paper_id,
+                "recursive": None,
+            }
+        )
+
+    @_synchronized
     def counts(self) -> dict[str, int]:
         """Return the total paper and theorem counts."""
 
@@ -3974,6 +4098,292 @@ def _reading_queue_item_from_row(row: tuple) -> dict:
         "evidence": json.loads(row[7]),
         "created_at": row[8],
     }
+
+
+class _ExternalImportPlanCollector:
+    def __init__(self, workspace: Workspace):
+        self._workspace = workspace
+        self._candidates: dict[str, dict] = {}
+        self._blocked: dict[str, dict] = {}
+
+    def add_external_mention(self, mention_id: str, source: str) -> None:
+        mention = self._external_mention(mention_id)
+        evidence = [
+            _external_import_evidence(
+                "external_result_mention",
+                mention["mention_id"],
+                mention["paper_id"],
+                self._result_id_for_proof(mention["proof_id"]),
+                mention["proof_id"],
+                None,
+                mention["raw_text"],
+                source,
+            )
+        ]
+        arxiv_id = None
+        arxiv_version = None
+        if mention["citation_mention_id"]:
+            citation = self._citation_mention(mention["citation_mention_id"])
+            evidence.append(
+                _external_import_evidence(
+                    "citation_mention",
+                    citation["mention_id"],
+                    citation["paper_id"],
+                    self._result_id_for_proof(citation["proof_id"]),
+                    citation["proof_id"],
+                    citation["raw_key"],
+                    citation["raw_text"],
+                    "result.citation_mention",
+                )
+            )
+            if citation["entry_id"]:
+                entry = self._bibliography_entry(citation["entry_id"])
+                evidence.append(_bibliography_entry_evidence(entry, "result.bibliography_entry"))
+                arxiv_id = entry["arxiv_id"]
+                arxiv_version = entry["arxiv_version"]
+        if mention["entry_id"] and not arxiv_id:
+            entry = self._bibliography_entry(mention["entry_id"])
+            evidence.append(_bibliography_entry_evidence(entry, "result.bibliography_entry"))
+            arxiv_id = entry["arxiv_id"]
+            arxiv_version = entry["arxiv_version"]
+
+        if arxiv_id:
+            self._add_candidate(arxiv_id, arxiv_version, evidence)
+        else:
+            self.add_blocked("missing_arxiv_id", evidence)
+
+    def add_citation_mention(self, mention_id: str, source: str) -> None:
+        citation = self._citation_mention(mention_id)
+        evidence = [
+            _external_import_evidence(
+                "citation_mention",
+                citation["mention_id"],
+                citation["paper_id"],
+                self._result_id_for_proof(citation["proof_id"]),
+                citation["proof_id"],
+                citation["raw_key"],
+                citation["raw_text"],
+                source,
+            )
+        ]
+        if not citation["entry_id"]:
+            self.add_blocked("missing_arxiv_id", evidence)
+            return
+
+        entry = self._bibliography_entry(citation["entry_id"])
+        evidence.append(_bibliography_entry_evidence(entry, "paper.bibliography_entry"))
+        if entry["arxiv_id"]:
+            self._add_candidate(entry["arxiv_id"], entry["arxiv_version"], evidence)
+        else:
+            self.add_blocked("missing_arxiv_id", evidence)
+
+    def add_blocked(self, reason: str, evidence: list[dict]) -> None:
+        stable = "|".join(f"{item['kind']}:{item['id']}" for item in evidence)
+        blocked_id = f"external-import:blocked:{slug_fragment(stable)}"
+        existing = self._blocked.setdefault(
+            blocked_id,
+            {
+                "blocked_id": blocked_id,
+                "reason": reason,
+                "evidence": [],
+            },
+        )
+        existing["evidence"] = _dedupe_external_import_evidence(
+            [*existing["evidence"], *evidence]
+        )
+
+    def payload(self, scope: dict) -> dict:
+        candidates = [self._candidate_payload(candidate) for candidate in self._candidates.values()]
+        candidates.sort(
+            key=lambda candidate: (
+                0 if candidate["status"] == "import_candidate" else 1,
+                candidate["source"]["arxiv_id"],
+                candidate["candidate_id"],
+            )
+        )
+        blocked = list(self._blocked.values())
+        blocked.sort(key=lambda item: (item["reason"], item["blocked_id"]))
+        for item in blocked:
+            item["evidence"] = _dedupe_external_import_evidence(item["evidence"])
+        return {
+            "plan_schema_version": 1,
+            "scope": scope,
+            "candidates": candidates,
+            "blocked": blocked,
+            "summary": {
+                "candidate_count": len(candidates),
+                "import_candidate_count": sum(
+                    1 for candidate in candidates if candidate["status"] == "import_candidate"
+                ),
+                "already_imported_count": sum(
+                    1 for candidate in candidates if candidate["status"] == "already_imported"
+                ),
+                "blocked_count": len(blocked),
+            },
+            "warnings": _dedupe_strings(
+                warning
+                for candidate in candidates
+                for warning in candidate.get("warnings", [])
+            ),
+        }
+
+    def _add_candidate(
+        self,
+        arxiv_id: str,
+        arxiv_version: str | None,
+        evidence: list[dict],
+    ) -> None:
+        candidate_id = f"external-import:arxiv:{arxiv_id}"
+        candidate = self._candidates.setdefault(
+            arxiv_id,
+            {
+                "candidate_id": candidate_id,
+                "arxiv_id": arxiv_id,
+                "versions": set(),
+                "evidence": [],
+            },
+        )
+        if arxiv_version:
+            candidate["versions"].add(arxiv_version)
+        candidate["evidence"] = _dedupe_external_import_evidence(
+            [*candidate["evidence"], *evidence]
+        )
+
+    def _candidate_payload(self, candidate: dict) -> dict:
+        arxiv_id = candidate["arxiv_id"]
+        versions = sorted(candidate["versions"])
+        status = (
+            "already_imported"
+            if self._workspace._paper_exists(f"arxiv:{arxiv_id}")
+            else "import_candidate"
+        )
+        warnings = ["conflicting_versions"] if len(versions) > 1 else []
+        evidence = _dedupe_external_import_evidence(candidate["evidence"])
+        return {
+            "candidate_id": candidate["candidate_id"],
+            "status": status,
+            "source": {
+                "type": "arxiv",
+                "arxiv_id": arxiv_id,
+                "arxiv_version": versions[-1] if versions else None,
+                "recommended_paper_id": f"arxiv:{arxiv_id}",
+            },
+            "evidence": evidence,
+            "counts": {
+                "external_mentions": sum(
+                    1 for item in evidence if item["kind"] == "external_result_mention"
+                ),
+                "citation_mentions": sum(
+                    1 for item in evidence if item["kind"] == "citation_mention"
+                ),
+                "bibliography_entries": sum(
+                    1 for item in evidence if item["kind"] == "bibliography_entry"
+                ),
+            },
+            "warnings": warnings,
+        }
+
+    def _external_mention(self, mention_id: str) -> dict:
+        row = self._workspace._connection.execute(
+            """
+            SELECT
+                mention_id, paper_id, proof_id, citation_mention_id,
+                raw_text, external_kind, external_number, entry_id,
+                target_paper_id, resolution_status, method, confidence
+            FROM external_result_mentions
+            WHERE mention_id = ?
+            """,
+            (mention_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown external result mention id: {mention_id}")
+        return _external_result_mention_from_row(row)
+
+    def _citation_mention(self, mention_id: str) -> dict:
+        row = self._workspace._connection.execute(
+            """
+            SELECT
+                mention_id, paper_id, proof_id, raw_text, raw_key, entry_id,
+                resolution_status, method, confidence
+            FROM citation_mentions
+            WHERE mention_id = ?
+            """,
+            (mention_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown citation mention id: {mention_id}")
+        return _citation_mention_from_row(row)
+
+    def _bibliography_entry(self, entry_id: str) -> dict:
+        row = self._workspace._connection.execute(
+            """
+            SELECT
+                entry_id, paper_id, raw_label, raw_text, entry_type, title,
+                authors_json, year, arxiv_id, arxiv_version, doi, url,
+                method, confidence
+            FROM bibliography_entries
+            WHERE entry_id = ?
+            """,
+            (entry_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown bibliography entry id: {entry_id}")
+        return _bibliography_entry_from_row(row)
+
+    def _result_id_for_proof(self, proof_id: str | None) -> str | None:
+        if proof_id is None:
+            return None
+        row = self._workspace._connection.execute(
+            "SELECT result_id FROM proofs WHERE proof_id = ?",
+            (proof_id,),
+        ).fetchone()
+        return row[0] if row else None
+
+
+def _external_import_evidence(
+    kind: str,
+    evidence_id: str,
+    paper_id: str,
+    result_id: str | None,
+    proof_id: str | None,
+    citation_key: str | None,
+    raw_text: str | None,
+    source: str,
+) -> dict:
+    return {
+        "kind": kind,
+        "id": evidence_id,
+        "paper_id": paper_id,
+        "result_id": result_id,
+        "proof_id": proof_id,
+        "citation_key": citation_key,
+        "raw_text": raw_text,
+        "source": source,
+    }
+
+
+def _bibliography_entry_evidence(entry: dict, source: str) -> dict:
+    return _external_import_evidence(
+        "bibliography_entry",
+        entry["entry_id"],
+        entry["paper_id"],
+        None,
+        None,
+        entry["raw_label"],
+        entry["raw_text"],
+        source,
+    )
+
+
+def _dedupe_external_import_evidence(items: list[dict]) -> list[dict]:
+    deduped = {
+        (item["kind"], item["id"], item["source"]): item
+        for item in items
+    }
+    return [
+        deduped[key]
+        for key in sorted(deduped, key=lambda value: (value[0], value[1], value[2]))
+    ]
 
 
 def _paper_from_row(row: tuple) -> dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.8.0\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.9.0\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(
@@ -74,11 +74,11 @@ def test_doctor_prints_json_without_starting_mcp(
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.8.0",
-            "release_tag": "v0.8.0",
+            "version": "0.9.0",
+            "release_tag": "v0.9.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.8.0"
+                "papergraph-mcp.git@v0.9.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -88,7 +88,7 @@ def test_doctor_prints_json_without_starting_mcp(
 
     server.main(["doctor"])
 
-    assert json.loads(capsys.readouterr().out)["version"] == "0.8.0"
+    assert json.loads(capsys.readouterr().out)["version"] == "0.9.0"
 
 
 def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(

--- a/tests/test_cli_external_import_planner.py
+++ b/tests/test_cli_external_import_planner.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+
+import fitz
+import pytest
+
+import papergraph.server as server
+from papergraph.workspace import Workspace
+
+
+def write_import_plan_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def create_import_plan_workspace(tmp_path: Path) -> Path:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_import_plan_pdf(pdf)
+    workspace = Workspace.open(workspace_path)
+    try:
+        workspace.import_pdf(pdf, "local:paper")
+        workspace.create_reading_queue("local:paper::pdf:theorem:1.1")
+    finally:
+        workspace.close()
+    return workspace_path
+
+
+def read_json(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_plan_external_imports_for_result_cli_prints_json(tmp_path: Path, capsys):
+    workspace_path = create_import_plan_workspace(tmp_path)
+
+    server.main(
+        [
+            "plan-external-imports-for-result",
+            "--workspace",
+            str(workspace_path),
+            "--result-id",
+            "local:paper::pdf:theorem:1.1",
+        ]
+    )
+
+    payload = read_json(capsys)
+    assert payload["scope"]["kind"] == "result_id"
+    assert payload["candidates"][0]["source"]["arxiv_id"] == "2401.12345"
+
+
+def test_external_import_planner_cli_round_trip(tmp_path: Path, capsys):
+    workspace_path = create_import_plan_workspace(tmp_path)
+
+    server.main(["list-reading-queues", "--workspace", str(workspace_path)])
+    queue_id = json.loads(capsys.readouterr().out)[0]["queue_id"]
+
+    server.main(
+        [
+            "plan-external-imports-for-queue",
+            "--workspace",
+            str(workspace_path),
+            "--queue-id",
+            queue_id,
+        ]
+    )
+    queue_plan = read_json(capsys)
+    assert queue_plan["summary"]["candidate_count"] == 1
+
+    server.main(
+        [
+            "plan-external-imports-for-paper",
+            "--workspace",
+            str(workspace_path),
+            "--paper-id",
+            "local:paper",
+        ]
+    )
+    paper_plan = read_json(capsys)
+    assert paper_plan["scope"]["kind"] == "paper_id"
+    assert paper_plan["summary"]["import_candidate_count"] == 1
+
+
+def test_plan_external_imports_cli_reports_unknown_queue(tmp_path: Path, capsys):
+    workspace_path = create_import_plan_workspace(tmp_path)
+
+    with pytest.raises(SystemExit) as caught:
+        server.main(
+            [
+                "plan-external-imports-for-queue",
+                "--workspace",
+                str(workspace_path),
+                "--queue-id",
+                "queue:missing",
+            ]
+        )
+
+    assert caught.value.code == 1
+    payload = read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["command"] == "plan-external-imports-for-queue"
+    assert "Unknown reading queue id" in payload["message"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,11 +5,11 @@ def test_environment_diagnostics_reports_version_and_release_source():
     result = environment_diagnostics()
 
     assert result["package_name"] == "papergraph-mcp"
-    assert result["version"] == "0.8.0"
-    assert result["release_tag"] == "v0.8.0"
+    assert result["version"] == "0.9.0"
+    assert result["release_tag"] == "v0.9.0"
     assert (
         result["recommended_source"]
-        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0"
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0"
     )
     assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
     assert isinstance(result["warnings"], list)
@@ -25,6 +25,6 @@ def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
 
     result = environment_diagnostics()
 
-    assert result["version"] == "0.8.0"
+    assert result["version"] == "0.9.0"
     assert result["git"] is None
     assert any("Git context unavailable" in warning for warning in result["warnings"])

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.8.0"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.8.0\n"
+        stdout = "papergraph-mcp 0.9.0\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.8.0"
+    assert result["version"] == "papergraph-mcp 0.9.0"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.8.0"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.9.0"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -350,7 +350,7 @@ def test_readme_exposes_agent_guided_setup():
     assert ".agents/skills/setting-up-papergraph/SKILL.md" in text
 
 
-def test_all_onboarding_source_pins_match_v080():
+def test_all_onboarding_source_pins_match_v090():
     import re
 
     combined = "\n".join(
@@ -361,4 +361,4 @@ def test_all_onboarding_source_pins_match_v080():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.8.0"}
+    assert set(refs) == {"v0.9.0"}

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,7 +24,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.8.0"
+    assert project["version"] == "0.9.0"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -70,7 +70,7 @@ def test_lockfile_contains_project_package():
     )
 
     assert package["name"] == "papergraph-mcp"
-    assert package["version"] == "0.8.0"
+    assert package["version"] == "0.9.0"
 
 
 def test_validate_arxiv_request_module_stdout_is_json_only():
@@ -102,8 +102,8 @@ def test_runtime_and_issue_template_release_strings_remain_pinned():
         if item.get("id") == "version"
     )
 
-    assert f'PaperGraph/0.8.0 (+{REPOSITORY_URL})' in arxiv_source
-    assert version_field["attributes"]["placeholder"] == "0.8.0"
+    assert f'PaperGraph/0.9.0 (+{REPOSITORY_URL})' in arxiv_source
+    assert version_field["attributes"]["placeholder"] == "0.9.0"
 
 
 def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
@@ -144,7 +144,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.8.0" in build_steps
+    assert "papergraph-mcp 0.9.0" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -252,7 +252,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.8.0"
+        "papergraph-mcp.git@v0.9.0"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):
@@ -263,7 +263,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     )
     assert '"command": "uvx"' in readme
     assert pinned_source in readme
-    assert "PaperGraph v0.8.0" in readme
+    assert "PaperGraph v0.9.0" in readme
 
     for tool_name in (
         "load_paper",
@@ -307,6 +307,9 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
         "workspace_list_reading_queues",
         "workspace_get_reading_queue",
         "workspace_apply_reading_queue_to_session",
+        "workspace_plan_external_imports_for_result",
+        "workspace_plan_external_imports_for_queue",
+        "workspace_plan_external_imports_for_paper",
     ):
         assert f"`{tool_name}`" in readme
 
@@ -330,6 +333,9 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     assert "list-reading-queues" in readme
     assert "get-reading-queue" in readme
     assert "apply-reading-queue-to-session" in readme
+    assert "plan-external-imports-for-result" in readme
+    assert "plan-external-imports-for-queue" in readme
+    assert "plan-external-imports-for-paper" in readme
     assert "--workspace" in readme
     assert "`get_environment_diagnostics`" in readme
     assert "`validate_arxiv_request`" in readme
@@ -388,8 +394,8 @@ def test_onboarding_uses_v061_release_pin_and_mentions_id_url_conflicts():
         ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
     ).read_text(encoding="utf-8")
 
-    assert "papergraph-mcp.git@v0.8.0" in skill
-    assert "papergraph-mcp 0.8.0" in skill
+    assert "papergraph-mcp.git@v0.9.0" in skill
+    assert "papergraph-mcp 0.9.0" in skill
     assert "validate_arxiv_request" in skill
     assert "load_arxiv_request" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,11 +169,11 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.8.0",
-            "release_tag": "v0.8.0",
+            "version": "0.9.0",
+            "release_tag": "v0.9.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.8.0"
+                "papergraph-mcp.git@v0.9.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -181,7 +181,7 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         },
     )
 
-    assert server.get_environment_diagnostics()["release_tag"] == "v0.8.0"
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.9.0"
 
 
 def test_validate_arxiv_input_tool_reports_conflict():

--- a/tests/test_workspace_external_import_planner.py
+++ b/tests/test_workspace_external_import_planner.py
@@ -153,6 +153,44 @@ def test_paper_plan_includes_citation_evidence_without_queue(tmp_path: Path):
         workspace.close()
 
 
+def test_result_plan_preserves_unresolved_stop_paper_id(tmp_path: Path, monkeypatch):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        result_id = import_import_plan_pdf(workspace, tmp_path)
+        original_get_result = workspace.get_result
+        external_result = {
+            "paper_id": "arxiv:dep",
+            "result_id": "arxiv:dep::tex:theorem:t",
+        }
+
+        def fake_get_result(requested_id: str):
+            if requested_id == external_result["result_id"]:
+                return external_result
+            return original_get_result(requested_id)
+
+        monkeypatch.setattr(workspace, "get_result", fake_get_result)
+        monkeypatch.setattr(
+            workspace,
+            "get_result_reading_path",
+            lambda _result_id, recursive=True: {
+                "external_stops": [],
+                "unresolved_stops": [
+                    {
+                        "result_id": external_result["result_id"],
+                        "kind": "unresolved_local_results",
+                        "mentions": [],
+                    }
+                ],
+            },
+        )
+
+        plan = workspace.plan_external_imports_for_result(result_id)
+
+        assert plan["blocked"][0]["evidence"][0]["paper_id"] == "arxiv:dep"
+    finally:
+        workspace.close()
+
+
 def test_plan_rejects_non_boolean_recursive(tmp_path: Path):
     workspace = Workspace.open(tmp_path / "workspace.sqlite3")
     try:

--- a/tests/test_workspace_external_import_planner.py
+++ b/tests/test_workspace_external_import_planner.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import fitz
+import pytest
+
+from papergraph.project import load_project
+from papergraph.workspace import Workspace
+
+
+def write_import_plan_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2, Lemma 9.9, and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def import_import_plan_pdf(workspace: Workspace, tmp_path: Path) -> str:
+    pdf = tmp_path / "paper.pdf"
+    write_import_plan_pdf(pdf)
+    workspace.import_pdf(pdf, "local:paper")
+    return "local:paper::pdf:theorem:1.1"
+
+
+def import_arxiv_target(workspace: Workspace, tmp_path: Path) -> None:
+    tex = tmp_path / "target.tex"
+    tex.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\begin{document}",
+                r"\begin{theorem}\label{t}",
+                "Imported target theorem.",
+                r"\end{theorem}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    workspace.import_project(
+        "arxiv:2401.12345",
+        "arxiv",
+        "2401.12345",
+        None,
+        load_project(tex),
+    )
+
+
+def test_result_plan_groups_external_mentions_by_arxiv(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        result_id = import_import_plan_pdf(workspace, tmp_path)
+
+        plan = workspace.plan_external_imports_for_result(result_id)
+
+        assert plan["plan_schema_version"] == 1
+        assert plan["scope"] == {
+            "kind": "result_id",
+            "value": result_id,
+            "paper_id": "local:paper",
+            "recursive": True,
+        }
+        assert plan["summary"]["candidate_count"] == 1
+        assert plan["summary"]["import_candidate_count"] == 1
+        candidate = plan["candidates"][0]
+        assert candidate["candidate_id"] == "external-import:arxiv:2401.12345"
+        assert candidate["status"] == "import_candidate"
+        assert candidate["source"] == {
+            "type": "arxiv",
+            "arxiv_id": "2401.12345",
+            "arxiv_version": "v2",
+            "recommended_paper_id": "arxiv:2401.12345",
+        }
+        assert {item["kind"] for item in candidate["evidence"]} >= {
+            "external_result_mention",
+            "citation_mention",
+            "bibliography_entry",
+        }
+        assert plan["summary"]["blocked_count"] == 1
+        assert plan["blocked"][0]["reason"] == "missing_arxiv_id"
+    finally:
+        workspace.close()
+
+
+def test_result_plan_marks_imported_arxiv_candidates(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        result_id = import_import_plan_pdf(workspace, tmp_path)
+        import_arxiv_target(workspace, tmp_path)
+
+        candidate = workspace.plan_external_imports_for_result(result_id)[
+            "candidates"
+        ][0]
+
+        assert candidate["status"] == "already_imported"
+        assert candidate["source"]["recommended_paper_id"] == "arxiv:2401.12345"
+    finally:
+        workspace.close()
+
+
+def test_queue_plan_uses_saved_queue_caution_items(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        result_id = import_import_plan_pdf(workspace, tmp_path)
+        queue = workspace.create_reading_queue(result_id)
+
+        plan = workspace.plan_external_imports_for_queue(queue["queue_id"])
+
+        assert plan["scope"] == {
+            "kind": "queue_id",
+            "value": queue["queue_id"],
+            "paper_id": "local:paper",
+            "recursive": None,
+        }
+        assert plan["summary"]["candidate_count"] == 1
+        assert plan["summary"]["blocked_count"] == 1
+        assert all(
+            evidence["source"].startswith(("reading_queue", "result"))
+            for candidate in plan["candidates"]
+            for evidence in candidate["evidence"]
+        )
+    finally:
+        workspace.close()
+
+
+def test_paper_plan_includes_citation_evidence_without_queue(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_import_plan_pdf(workspace, tmp_path)
+
+        plan = workspace.plan_external_imports_for_paper("local:paper")
+
+        assert plan["scope"] == {
+            "kind": "paper_id",
+            "value": "local:paper",
+            "paper_id": "local:paper",
+            "recursive": None,
+        }
+        assert plan["candidates"][0]["source"]["arxiv_id"] == "2401.12345"
+        assert plan["summary"]["import_candidate_count"] == 1
+    finally:
+        workspace.close()
+
+
+def test_plan_rejects_non_boolean_recursive(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        result_id = import_import_plan_pdf(workspace, tmp_path)
+
+        with pytest.raises(ValueError, match="recursive must be a boolean"):
+            workspace.plan_external_imports_for_result(result_id, recursive="yes")
+    finally:
+        workspace.close()

--- a/tests/test_workspace_external_import_planner_server.py
+++ b/tests/test_workspace_external_import_planner_server.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import fitz
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+
+import papergraph.server as server
+
+
+def write_import_plan_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    server._reset_server_state()
+    yield
+    server._reset_server_state()
+
+
+def load_workspace(tmp_path: Path) -> None:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_import_plan_pdf(pdf)
+
+    server.open_workspace(str(workspace_path))
+    server.workspace_add_pdf_paper(str(pdf), "local:paper")
+
+
+def test_external_import_planner_mcp_tools_return_payloads(tmp_path: Path):
+    load_workspace(tmp_path)
+    result_id = "local:paper::pdf:theorem:1.1"
+
+    result_plan = server.workspace_plan_external_imports_for_result(result_id)
+    queue = server.workspace_create_reading_queue(result_id)
+    queue_plan = server.workspace_plan_external_imports_for_queue(queue["queue_id"])
+    paper_plan = server.workspace_plan_external_imports_for_paper("local:paper")
+
+    assert result_plan["candidates"][0]["source"]["arxiv_id"] == "2401.12345"
+    assert queue_plan["scope"]["kind"] == "queue_id"
+    assert paper_plan["summary"]["import_candidate_count"] == 1
+
+
+def test_external_import_planner_mcp_tools_report_missing_workspace():
+    with pytest.raises(ToolError, match="open_workspace"):
+        server.workspace_plan_external_imports_for_result(
+            "local:paper::pdf:theorem:1.1"
+        )
+
+
+def test_external_import_planner_mcp_tools_convert_workspace_errors(tmp_path: Path):
+    server.open_workspace(str(tmp_path / "workspace.sqlite3"))
+
+    with pytest.raises(ToolError, match="Unknown reading queue id"):
+        server.workspace_plan_external_imports_for_queue("queue:missing")

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add read-only External Import Planner workspace APIs for result, queue, and paper scopes
- group stored external/citation/bibliography evidence into deterministic arXiv import candidates
- mark already-imported arXiv papers and preserve blocked non-actionable evidence
- expose planner through MCP tools and JSON CLI commands
- prepare v0.9.0 docs, onboarding pins, diagnostics, and release metadata

## Testing
- `uv run pytest`
- Result: `411 passed, 1 skipped in 34.97s`

## Notes
- No subagents were used for implementation or review.
- Planning is read-only: it does not download papers or call live arXiv.