### PR TITLE
Add TeX proof block association for v0.9.1

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -47,23 +47,23 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.9.0`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.9.1`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version
 ```
 
 The expected output is:
 
 ```text
-papergraph-mcp 0.9.0
+papergraph-mcp 0.9.1
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.9.0"
+      placeholder: "0.9.1"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.9.0"
+          test "$version" = "papergraph-mcp 0.9.1"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/lotchuazzz-crypto/papergraph-mcp)](https://github.com/lotchuazzz-crypto/papergraph-mcp/releases)
 
-PaperGraph turns local or arXiv LaTeX papers and born-digital PDFs into evidence-first theorem, result, proof, reading-session, reading-queue, and external-import planning state that AI agents can query through MCP. PaperGraph v0.9.0 adds an External Import Planner so agents can turn external proof stops and citation evidence into a deterministic list of arXiv papers to import next.
+PaperGraph turns local or arXiv LaTeX papers and born-digital PDFs into evidence-first theorem, result, proof, reading-session, reading-queue, and external-import planning state that AI agents can query through MCP. PaperGraph v0.9.1 associates TeX proof environments to the immediately preceding result, so proof-local label references can feed reading paths instead of reporting `proof: not_found`.
+
+PaperGraph v0.9.0 added an External Import Planner so agents can turn external proof stops and citation evidence into a deterministic list of arXiv papers to import next.
 
 PaperGraph v0.8.0 added a persistent Reading Queue Planner so agents can turn local proof-dependency paths into required, recommended, and caution reading targets, then apply those targets to resumable reading sessions.
 
@@ -27,6 +29,7 @@ Single-paper tools expose theorem-like environments, labels, and `\ref` relation
 
 - Load local single-file or multi-file LaTeX projects, or safely prepare arXiv source projects.
 - Import born-digital PDFs into the same local workspace and inspect extracted result and proof evidence.
+- Associate TeX proof environments with the immediately preceding result and expose proof-local references.
 - Export reading bridge bundles, result contexts, source slices, and reading paths for explanation-focused consumers.
 - Persist reading sessions, checkpoints, notes, open questions, and recovery summaries in the local workspace.
 - Plan deterministic reading queues from proof-dependency evidence and apply them to reading sessions.
@@ -64,11 +67,11 @@ the decision without loading, call `validate_arxiv_request` or
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the GitHub release without cloning the repository:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
-The pinned command becomes available after the `v0.9.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.9.1` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 To validate a raw arXiv request before loading a paper, run:
 
@@ -85,7 +88,7 @@ For an MCP client that accepts JSON-style stdio server configuration, add:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1", "papergraph-mcp"]
     }
   }
 }

--- a/docs/superpowers/plans/2026-09-08-proof-block-association-v0.9.1.md
+++ b/docs/superpowers/plans/2026-09-08-proof-block-association-v0.9.1.md
@@ -1,0 +1,310 @@
+# Proof Block Association v0.9.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build conservative TeX proof environment extraction and adjacent result association for v0.9.1.
+
+**Architecture:** Extend `papergraph.parser` so LaTeX imports emit proof source spans and `ProofEvidence` records instead of an empty proof tuple. Reuse existing proof-local mention and citation extractors so downstream reading paths and external import planning begin working for TeX projects without schema changes.
+
+**Tech Stack:** Python 3.10+, existing LaTeX parser regex approach, existing evidence dataclasses, SQLite workspace import path, pytest.
+
+## Global Constraints
+
+- Release version is `0.9.1`.
+- No subagents for this implementation.
+- No SQLite schema changes.
+- No live arXiv calls while extracting proofs.
+- TeX proof association must be conservative and deterministic.
+- v0.9.1 does not implement roadmap extraction or citation-level import planning.
+
+---
+
+## File Structure
+
+- Modify `src/papergraph/parser.py`: parse TeX proof environments, build proof spans, associate proofs to adjacent results, and reuse evidence extractors.
+- Modify `tests/test_project.py`: cover TeX proof extraction at evidence-document level.
+- Modify `tests/test_workspace_evidence.py`: cover workspace proof and dependency behavior for TeX imports.
+- Modify `tests/test_workspace_external_import_planner.py`: cover planner visibility after TeX proof extraction.
+- Modify `README.md`, `pyproject.toml`, `uv.lock`, `.github/workflows/ci.yml`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `src/papergraph/arxiv.py`, `scripts/check_onboarding.py`, `.agents/skills/setting-up-papergraph/SKILL.md`, `.agents/skills/setting-up-papergraph/references/client-configuration.md`, and version-pinned tests for `v0.9.1`.
+
+---
+
+### Task 1: TeX Proof Extraction
+
+**Files:**
+- Modify: `src/papergraph/parser.py`
+- Test: `tests/test_project.py`
+
+**Interfaces:**
+- Consumes: `LoadedProject.text`, `LoadedProject.spans`, existing `ResultEvidence` records.
+- Produces: proof `SourceSpanEvidence` records and `ProofEvidence` records inside `latex_project_to_evidence_document(...)`.
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add tests that create a temporary TeX project and call:
+
+```python
+document = latex_project_to_evidence_document(
+    "local:paper",
+    "local",
+    str(tex_path),
+    None,
+    load_project(tex_path),
+)
+```
+
+Assert:
+
+- one theorem and one immediately following proof produce `len(document.proofs) == 1`
+- the proof has `result_id == "local:paper::th:main"`
+- the proof has `association_basis == "immediately_follows_result"`
+- the proof uses `method == "latex_proof_environment"`
+- a second proof after the same theorem remains unresolved with `result_id is None`
+
+- [ ] **Step 2: Run parser tests to verify red**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest tests/test_project.py -v
+```
+
+Expected: new tests fail because TeX imports currently emit no proof records.
+
+- [ ] **Step 3: Implement TeX proof blocks**
+
+In `src/papergraph/parser.py`:
+
+- import `ProofEvidence`
+- import `extract_local_result_mentions`, `extract_citation_mentions`, and `extract_external_result_mentions`
+- add a `ParsedProofBlock` dataclass or tuple carrying `position`, `body`, and optional title
+- parse `\begin{proof}...\end{proof}` over `project.text`
+- sort result nodes and proof blocks by source offset when associating
+- add proof spans after result spans so result span indices stay stable
+- create proof IDs as `f"{paper_id}::proof:{n}"`
+- for each proof, associate with nearest preceding result if that result has not already been associated and no proof block intervenes
+- use `association_confidence=0.8` for adjacent TeX proof association and `0.0` for unresolved proofs
+- use `confidence=1.0` for the environment extraction itself
+
+- [ ] **Step 4: Run parser tests to verify green**
+
+Run the same parser test command. Expected: all `tests/test_project.py` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/parser.py tests/test_project.py
+git commit -m "feat: extract tex proof environments"
+```
+
+---
+
+### Task 2: Workspace Proof Dependencies From TeX
+
+**Files:**
+- Modify: `tests/test_workspace_evidence.py`
+- Modify: `tests/test_workspace_external_import_planner.py`
+
+**Interfaces:**
+- Consumes: Task 1's TeX `ProofEvidence` records and existing workspace import.
+- Produces: verified `get_result_proof`, `get_proof_dependencies`, and external import planner behavior for TeX proof evidence.
+
+- [ ] **Step 1: Write failing workspace tests**
+
+Add tests that import TeX projects through `Workspace.import_project(...)`.
+
+Test local dependency:
+
+```latex
+\newtheorem{theorem}{Theorem}
+\newtheorem{lemma}{Lemma}
+\begin{lemma}\label{lem:base}
+Base lemma.
+\end{lemma}
+\begin{theorem}\label{th:main}
+Main theorem.
+\end{theorem}
+\begin{proof}
+By \cref{lem:base}.
+\end{proof}
+```
+
+Assert:
+
+- `get_result_proof("local:paper::th:main")` has a known proof
+- `get_proof_dependencies(..., recursive=False)` includes `local:paper::lem:base` in `known.resolved_local_results`
+- the reading path has an edge from theorem to lemma
+
+Test external dependency:
+
+```latex
+\begin{theorem}\label{th:main}
+Main theorem.
+\end{theorem}
+\begin{proof}
+We apply [12, Theorem 3.5].
+\end{proof}
+```
+
+Import an `EvidenceDocument` or workspace fixture that includes bibliography entry `[12] ... arXiv:2401.12345v2` if the TeX project path does not yet parse `.bib` entries into bibliography evidence. Assert `plan_external_imports_for_result` reports one candidate `2401.12345`.
+
+- [ ] **Step 2: Run workspace tests to verify red**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_evidence.py tests/test_workspace_external_import_planner.py -v
+```
+
+Expected: local proof/dependency tests fail before Task 1 implementation, then pass after Task 1; external planner test may require adding bibliography evidence support through the existing import path or scoped fixture.
+
+- [ ] **Step 3: Adjust implementation only if workspace integration exposes gaps**
+
+If local dependencies do not resolve:
+
+- confirm `extract_local_result_mentions` runs over Task 1 proofs
+- confirm proof span indices point to proof text
+- confirm result labels are visible in `_result_lookup`
+
+If external planner cannot see `[12, Theorem 3.5]` because TeX bibliography evidence is absent, keep v0.9.1 focused and test citation mention extraction only when a bibliography entry is present through existing evidence document fixtures. Do not implement full BibTeX parsing in this patch.
+
+- [ ] **Step 4: Run workspace tests to verify green**
+
+Run the same command. Expected: all selected workspace tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add tests/test_workspace_evidence.py tests/test_workspace_external_import_planner.py src/papergraph/parser.py
+git commit -m "test: cover tex proof dependency integration"
+```
+
+---
+
+### Task 3: v0.9.1 Release Pins and Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `scripts/check_onboarding.py`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_diagnostics.py`
+- Modify: `tests/test_server.py`
+
+**Interfaces:**
+- Consumes: Task 1-2 behavior.
+- Produces: release-ready docs and version metadata for `v0.9.1`.
+
+- [ ] **Step 1: Update version tests first**
+
+Change tests from `0.9.0`/`v0.9.0` to `0.9.1`/`v0.9.1`. Add a README expectation mentioning TeX proof environment association.
+
+- [ ] **Step 2: Run docs tests to verify red**
+
+Run:
+
+```powershell
+uv run pytest tests/test_repository.py tests/test_onboarding.py tests/test_cli.py tests/test_diagnostics.py tests/test_server.py -v
+```
+
+Expected: failures until release pins and README are updated.
+
+- [ ] **Step 3: Update docs and pins**
+
+Update all active release pins and README language to v0.9.1. Add a concise README note that TeX proof environments are associated to immediately preceding results and feed proof dependency extraction.
+
+- [ ] **Step 4: Run docs tests to verify green**
+
+Run the same docs test command. Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add README.md pyproject.toml uv.lock .github/workflows/ci.yml .github/ISSUE_TEMPLATE/bug_report.yml src/papergraph/arxiv.py scripts/check_onboarding.py .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/client-configuration.md tests/test_repository.py tests/test_onboarding.py tests/test_cli.py tests/test_diagnostics.py tests/test_server.py
+git commit -m "docs: prepare v0.9.1 release"
+```
+
+---
+
+### Task 4: Final Verification, PR, and Release
+
+**Files:**
+- No expected code changes unless verification exposes a bug.
+
+**Interfaces:**
+- Consumes: completed v0.9.1 branch.
+- Produces: PR, merge to main, `v0.9.1` tag, GitHub Release.
+
+- [ ] **Step 1: Run full local verification**
+
+Run:
+
+```powershell
+$env:TMP = (Resolve-Path '.').Path + '\.tmp'
+$env:TEMP = $env:TMP
+New-Item -ItemType Directory -Force -Path $env:TMP | Out-Null
+uv run pytest
+```
+
+Expected: all tests pass with one skipped.
+
+- [ ] **Step 2: Self-review branch state**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --oneline --decorate --max-count=12
+rg -n 'papergraph-mcp\.git@v0\.9\.0|papergraph-mcp 0\.9\.0|PaperGraph/0\.9\.0|placeholder: "0\.9\.0"' README.md pyproject.toml uv.lock .github scripts src tests .agents/skills/setting-up-papergraph
+```
+
+Expected: clean worktree and no active v0.9.0 release pins.
+
+- [ ] **Step 3: Push and create PR**
+
+Run:
+
+```powershell
+git push -u origin feature/v0.9.1-proof-block-association
+```
+
+Create a PR from `feature/v0.9.1-proof-block-association` to `main` titled `Add TeX proof block association for v0.9.1`.
+
+- [ ] **Step 4: Wait for PR CI**
+
+Wait for GitHub Actions CI on the PR head SHA. Expected: success.
+
+- [ ] **Step 5: Merge PR**
+
+Squash merge after PR CI passes.
+
+- [ ] **Step 6: Wait for main CI**
+
+Fetch `origin/main`, confirm merge commit, and wait for push CI on main. Expected: success.
+
+- [ ] **Step 7: Tag and verify pinned install**
+
+Create and push:
+
+```powershell
+git tag -a v0.9.1 <main-merge-sha> -m "PaperGraph MCP v0.9.1"
+git push origin v0.9.1
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version
+```
+
+Expected: `papergraph-mcp 0.9.1`.
+
+- [ ] **Step 8: Create GitHub Release**
+
+Create GitHub Release `PaperGraph MCP v0.9.1` on tag `v0.9.1` with highlights and verification evidence.

--- a/docs/superpowers/plans/2026-09-08-proof-block-association-v0.9.1.md
+++ b/docs/superpowers/plans/2026-09-08-proof-block-association-v0.9.1.md
@@ -4,7 +4,7 @@
 
 **Goal:** Build conservative TeX proof environment extraction and adjacent result association for v0.9.1.
 
-**Architecture:** Extend `papergraph.parser` so LaTeX imports emit proof source spans and `ProofEvidence` records instead of an empty proof tuple. Reuse existing proof-local mention and citation extractors so downstream reading paths and external import planning begin working for TeX projects without schema changes.
+**Architecture:** Extend `papergraph.parser` so LaTeX imports emit proof source spans and `ProofEvidence` records instead of an empty proof tuple. Reuse and extend proof-local mention and citation extractors so downstream reading paths and external import planning begin working for TeX projects without schema changes.
 
 **Tech Stack:** Python 3.10+, existing LaTeX parser regex approach, existing evidence dataclasses, SQLite workspace import path, pytest.
 
@@ -22,6 +22,7 @@
 ## File Structure
 
 - Modify `src/papergraph/parser.py`: parse TeX proof environments, build proof spans, associate proofs to adjacent results, and reuse evidence extractors.
+- Modify `src/papergraph/evidence_extractors.py`: resolve proof-local LaTeX label refs to stored local result labels.
 - Modify `tests/test_project.py`: cover TeX proof extraction at evidence-document level.
 - Modify `tests/test_workspace_evidence.py`: cover workspace proof and dependency behavior for TeX imports.
 - Modify `tests/test_workspace_external_import_planner.py`: cover planner visibility after TeX proof extraction.
@@ -33,6 +34,7 @@
 
 **Files:**
 - Modify: `src/papergraph/parser.py`
+- Modify: `src/papergraph/evidence_extractors.py`
 - Test: `tests/test_project.py`
 
 **Interfaces:**
@@ -59,6 +61,7 @@ Assert:
 - the proof has `result_id == "local:paper::th:main"`
 - the proof has `association_basis == "immediately_follows_result"`
 - the proof uses `method == "latex_proof_environment"`
+- proof-local `\cref{lem:base}` produces a resolved local result mention
 - a second proof after the same theorem remains unresolved with `result_id is None`
 
 - [ ] **Step 2: Run parser tests to verify red**
@@ -80,6 +83,7 @@ In `src/papergraph/parser.py`:
 
 - import `ProofEvidence`
 - import `extract_local_result_mentions`, `extract_citation_mentions`, and `extract_external_result_mentions`
+- extend `extract_local_result_mentions` to parse `\ref`, `\eqref`, `\autoref`, `\cref`, and `\Cref` labels against `ResultEvidence.label`
 - add a `ParsedProofBlock` dataclass or tuple carrying `position`, `body`, and optional title
 - parse `\begin{proof}...\end{proof}` over `project.text`
 - sort result nodes and proof blocks by source offset when associating

--- a/docs/superpowers/specs/2026-09-08-proof-block-association-v0.9.1-design.md
+++ b/docs/superpowers/specs/2026-09-08-proof-block-association-v0.9.1-design.md
@@ -1,0 +1,126 @@
+# Proof Block Association v0.9.1 Design
+
+## Goal
+
+PaperGraph v0.9.1 fixes the first v0.9 reading gap: LaTeX projects with explicit `proof` environments should store proof evidence and associate each proof with the result it proves when the proof immediately follows that result.
+
+This is a focused patch release. It does not attempt proof-roadmap extraction or citation-level import planning; those remain planned for later v0.9.x releases.
+
+## Problem
+
+The PDF evidence path already extracts proof-like text blocks and associates an unlabeled `Proof.` block with the immediately preceding theorem-like result. The LaTeX project path does not. `latex_project_to_evidence_document` currently emits `proofs=()`, so TeX papers with ordinary:
+
+```latex
+\begin{theorem}\label{th:a}
+...
+\end{theorem}
+\begin{proof}
+...
+\end{proof}
+```
+
+produce `proof: not_found` even though the source contains a proof environment. This makes reading paths stop too early and hides proof-local references from downstream dependency tools.
+
+## Scope
+
+### In Scope
+
+- Discover `proof` environments in LaTeX project text.
+- Create `ProofEvidence` records for those environments.
+- Associate an unlabeled proof with the nearest preceding unassociated result when no other theorem-like result appears between the result and proof.
+- Preserve the existing `immediately_follows_result` basis for this adjacent association.
+- Store proof spans as TeX source evidence with accurate source file and source offsets.
+- Extract local result mentions, citation mentions, and external result mentions from the newly stored TeX proof evidence by reusing existing evidence extractor functions.
+- Update release pins from `0.9.0`/`v0.9.0` to `0.9.1`/`v0.9.1`.
+
+### Out of Scope
+
+- Named proof headings such as `Proof of Theorem 1.2` for TeX labels or numbers.
+- Narrative roadmap extraction, such as "we prove Theorem X by splitting it into A, B, C".
+- Turning plain citation lists into import candidates when no proof-local external result mention exists.
+- Semantic dependency inference or proof verification.
+- SQLite schema changes.
+
+## Public Behavior
+
+For a TeX project with adjacent result and proof environments:
+
+- `workspace_add_local_paper` and `workspace_add_arxiv_paper` imports report nonzero `proof_count`.
+- `workspace_get_result_proof(result_id)` returns:
+
+```python
+{
+    "known": {
+        "proof": {
+            "result_id": "...::th:a",
+            "association_basis": "immediately_follows_result",
+            "association_confidence": 0.8,
+            "method": "latex_proof_environment",
+        }
+    },
+    "inferred": [
+        {
+            "basis": "immediately_follows_result",
+            "confidence": 0.8,
+            "method": "latex_proof_environment",
+        }
+    ],
+    "unresolved": {},
+    "warnings": [],
+}
+```
+
+If the proof references another local result with `\ref`, `\cref`, `\Cref`, `\autoref`, or `\eqref`, the existing proof-dependency query should expose that mention when it names a stored result label.
+
+If the proof cites an external result with bracket notation already supported by PaperGraph, such as `[12, Theorem 3.5]`, the existing external import planner should see the resulting external mention after import.
+
+## Association Rule
+
+The v0.9.1 rule is deliberately conservative:
+
+1. Parse theorem-like environments and proof environments from the same combined LaTeX project text.
+2. Sort all result/proof blocks by source offset.
+3. For each proof environment, scan backward to the nearest preceding result block.
+4. Associate only if that result has not already been associated with another proof.
+5. Do not skip over another proof environment to reuse an older result.
+6. Leave the proof unresolved if no eligible preceding result exists.
+
+This matches common mathematical writing while avoiding broad inference.
+
+## Data Flow
+
+`latex_project_to_evidence_document` will:
+
+1. Parse result nodes as it does today.
+2. Parse proof blocks from `project.text`.
+3. Build `SourceSpanEvidence` for both result and proof blocks.
+4. Build `ResultEvidence` for result spans.
+5. Build `ProofEvidence` for proof spans with `result_id` set by the adjacent association rule.
+6. Call existing extractor helpers on those proofs:
+   - `extract_local_result_mentions`
+   - `extract_citation_mentions`
+   - `extract_external_result_mentions`
+7. Return one `EvidenceDocument` containing results, proofs, proof-local mentions, and external mentions.
+
+## Tests
+
+Add focused tests that fail on v0.9.0:
+
+- TeX project import stores a proof immediately following a theorem and `get_result_proof` no longer returns `proof: not_found`.
+- TeX proof-local `\cref{lem:a}` references resolve to local result mentions and appear in `get_proof_dependencies`.
+- TeX proof-local `[12, Theorem 3.5]` citation evidence creates an external import candidate through `plan_external_imports_for_result`.
+- A second proof immediately after the same result remains unresolved rather than stealing the same result twice.
+- Release tests expect `0.9.1` pins and `PaperGraph/0.9.1`.
+
+## Release
+
+Release as `v0.9.1` after:
+
+- local full `uv run pytest`
+- PR CI success on Ubuntu and Windows for Python 3.10 and 3.12
+- main CI success after merge
+- pinned install smoke test:
+
+```powershell
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1 papergraph-mcp --version
+```

--- a/docs/superpowers/specs/2026-09-08-proof-block-association-v0.9.1-design.md
+++ b/docs/superpowers/specs/2026-09-08-proof-block-association-v0.9.1-design.md
@@ -30,6 +30,7 @@ produce `proof: not_found` even though the source contains a proof environment. 
 - Associate an unlabeled proof with the nearest preceding unassociated result when no other theorem-like result appears between the result and proof.
 - Preserve the existing `immediately_follows_result` basis for this adjacent association.
 - Store proof spans as TeX source evidence with accurate source file and source offsets.
+- Resolve proof-local LaTeX label references such as `\cref{lem:a}` to stored local result labels.
 - Extract local result mentions, citation mentions, and external result mentions from the newly stored TeX proof evidence by reusing existing evidence extractor functions.
 - Update release pins from `0.9.0`/`v0.9.0` to `0.9.1`/`v0.9.1`.
 
@@ -70,7 +71,7 @@ For a TeX project with adjacent result and proof environments:
 }
 ```
 
-If the proof references another local result with `\ref`, `\cref`, `\Cref`, `\autoref`, or `\eqref`, the existing proof-dependency query should expose that mention when it names a stored result label.
+If the proof references another local result with `\ref`, `\cref`, `\Cref`, `\autoref`, or `\eqref`, the proof-dependency query exposes that mention when it names a stored result label.
 
 If the proof cites an external result with bracket notation already supported by PaperGraph, such as `[12, Theorem 3.5]`, the existing external import planner should see the resulting external mention after import.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.9.0"
+PAPERGRAPH_VERSION = "0.9.1"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.9.0"
+    "papergraph-mcp.git@v0.9.1"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -26,7 +26,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.9.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.9.1 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/src/papergraph/evidence_extractors.py
+++ b/src/papergraph/evidence_extractors.py
@@ -51,6 +51,9 @@ _CITATION_RE = re.compile(
     r"(?P<number>[A-Za-z]?(?:\d+(?:\.\d+)*|[A-Z])?))?\]",
     re.I,
 )
+_LATEX_REF_RE = re.compile(
+    r"\\(?:ref|eqref|autoref|cref|Cref)\{(?P<labels>[^}]+)\}"
+)
 
 
 def _normalized_text(text: str) -> str:
@@ -291,10 +294,40 @@ def extract_local_result_mentions(
     """Extract proof-local references to results in the same paper."""
 
     lookup = _result_lookup(results)
+    label_lookup = {
+        result.label: result
+        for result in results
+        if result.label is not None
+    }
     mentions: list[LocalResultMentionEvidence] = []
 
     for proof in proofs:
         excluded_ranges = _local_mention_excluded_ranges(proof.text)
+        for match in _LATEX_REF_RE.finditer(proof.text):
+            raw_text = match.group(0)
+            labels = [
+                label.strip()
+                for label in match.group("labels").split(",")
+                if label.strip()
+            ]
+            for label in labels:
+                result = label_lookup.get(label)
+                mentions.append(
+                    LocalResultMentionEvidence(
+                        mention_id=f"{paper_id}::local-mention:{len(mentions) + 1}",
+                        paper_id=paper_id,
+                        proof_id=proof.proof_id,
+                        raw_text=raw_text,
+                        kind=result.normalized_kind if result is not None else "label",
+                        visible_number=None,
+                        target_result_id=result.result_id if result is not None else None,
+                        resolution_status="resolved_unique"
+                        if result is not None
+                        else "unresolved",
+                        method="proof_latex_ref",
+                        confidence=0.9,
+                    )
+                )
         for match in _LOCAL_RESULT_MENTION_RE.finditer(proof.text):
             if _overlaps_any_range(match.span(), excluded_ranges):
                 continue

--- a/src/papergraph/evidence_extractors.py
+++ b/src/papergraph/evidence_extractors.py
@@ -294,11 +294,10 @@ def extract_local_result_mentions(
     """Extract proof-local references to results in the same paper."""
 
     lookup = _result_lookup(results)
-    label_lookup = {
-        result.label: result
-        for result in results
-        if result.label is not None
-    }
+    label_lookup: dict[str, list[ResultEvidence]] = {}
+    for result in results:
+        if result.label is not None:
+            label_lookup.setdefault(result.label, []).append(result)
     mentions: list[LocalResultMentionEvidence] = []
 
     for proof in proofs:
@@ -311,7 +310,14 @@ def extract_local_result_mentions(
                 if label.strip()
             ]
             for label in labels:
-                result = label_lookup.get(label)
+                matches = label_lookup.get(label, [])
+                result = matches[0] if len(matches) == 1 else None
+                if len(matches) == 1:
+                    resolution_status = "resolved_unique"
+                elif len(matches) > 1:
+                    resolution_status = "ambiguous"
+                else:
+                    resolution_status = "unresolved"
                 mentions.append(
                     LocalResultMentionEvidence(
                         mention_id=f"{paper_id}::local-mention:{len(mentions) + 1}",
@@ -321,9 +327,7 @@ def extract_local_result_mentions(
                         kind=result.normalized_kind if result is not None else "label",
                         visible_number=None,
                         target_result_id=result.result_id if result is not None else None,
-                        resolution_status="resolved_unique"
-                        if result is not None
-                        else "unresolved",
+                        resolution_status=resolution_status,
                         method="proof_latex_ref",
                         confidence=0.9,
                     )

--- a/src/papergraph/parser.py
+++ b/src/papergraph/parser.py
@@ -1,10 +1,17 @@
 import re
 from pathlib import Path
+from dataclasses import dataclass
 
 from papergraph.evidence import (
     EvidenceDocument,
+    ProofEvidence,
     ResultEvidence,
     SourceSpanEvidence,
+)
+from papergraph.evidence_extractors import (
+    extract_citation_mentions,
+    extract_external_result_mentions,
+    extract_local_result_mentions,
 )
 from papergraph.identity import global_theorem_id
 from papergraph.models import TheoremNode
@@ -33,6 +40,15 @@ LABEL_RE = re.compile(
 REF_RE = re.compile(
     r"\\(?:ref|eqref|autoref|cref|Cref)\{(?P<labels>[^}]+)\}"
 )
+PROOF_ENVIRONMENT_RE = re.compile(
+    r"""
+    \\begin\{proof\}
+    (?:\[(?P<title>[^\]]*)\])?
+    (?P<body>.*?)
+    \\end\{proof\}
+    """,
+    re.DOTALL | re.VERBOSE,
+)
 
 KIND_ALIASES = {
     "theorem": "theorem",
@@ -43,6 +59,14 @@ KIND_ALIASES = {
     "claim": "claim",
     "conjecture": "conjecture",
 }
+
+
+@dataclass(frozen=True, slots=True)
+class LatexProofBlock:
+    position: int
+    body_start: int
+    body_end: int
+    body: str
 
 
 def extract_refs(text: str) -> tuple[str, ...]:
@@ -173,6 +197,21 @@ def parse_project(project: LoadedProject) -> list[TheoremNode]:
     return nodes
 
 
+def parse_latex_proofs(text: str) -> list[LatexProofBlock]:
+    proofs: list[LatexProofBlock] = []
+    for match in PROOF_ENVIRONMENT_RE.finditer(text):
+        body = match.group("body")
+        proofs.append(
+            LatexProofBlock(
+                position=match.start(),
+                body_start=match.start("body"),
+                body_end=match.end("body"),
+                body=body.strip(),
+            )
+        )
+    return proofs
+
+
 def latex_project_to_evidence_document(
     paper_id: str,
     source_type: str,
@@ -181,6 +220,7 @@ def latex_project_to_evidence_document(
     project: LoadedProject,
 ) -> EvidenceDocument:
     nodes = parse_project(project)
+    proof_blocks = parse_latex_proofs(project.text)
     spans: list[SourceSpanEvidence] = []
     results: list[ResultEvidence] = []
 
@@ -232,6 +272,106 @@ def latex_project_to_evidence_document(
             )
         )
 
+    proof_block_indices = {
+        proof.position: index
+        for index, proof in enumerate(proof_blocks)
+    }
+    result_by_position = {
+        node.position: result
+        for node, result in zip(nodes, results)
+    }
+    associated_result_ids: set[str] = set()
+    previous_kind_by_proof_position: dict[int, str | None] = {}
+    previous_result_by_proof_position: dict[int, ResultEvidence | None] = {}
+    previous_kind: str | None = None
+    previous_result: ResultEvidence | None = None
+    events = [
+        *[("result", node.position) for node in nodes],
+        *[("proof", proof.position) for proof in proof_blocks],
+    ]
+    for kind, position in sorted(events, key=lambda event: event[1]):
+        if kind == "proof":
+            previous_kind_by_proof_position[position] = previous_kind
+            previous_result_by_proof_position[position] = previous_result
+        else:
+            previous_result = result_by_position[position]
+        previous_kind = kind
+
+    proofs: list[ProofEvidence] = []
+    for proof in proof_blocks:
+        project_span = next(
+            (
+                item
+                for item in project.spans
+                if item.start <= proof.position < item.end
+            ),
+            None,
+        )
+        if project_span is None:
+            raise ValueError("No source span contains proof environment")
+
+        span_index = len(spans)
+        spans.append(
+            SourceSpanEvidence(
+                paper_id=paper_id,
+                source_type="tex",
+                source_ref=project_span.path.relative_to(
+                    project.project_root
+                ).as_posix(),
+                page=None,
+                block_index=None,
+                start_offset=proof.body_start,
+                end_offset=proof.body_end,
+                bbox=None,
+                text=proof.body,
+                method="latex_proof_environment",
+                confidence=1.0,
+            )
+        )
+
+        previous_result = previous_result_by_proof_position[proof.position]
+        result_id = None
+        association_basis = "unresolved"
+        association_confidence = 0.0
+        if (
+            previous_kind_by_proof_position[proof.position] == "result"
+            and previous_result is not None
+            and previous_result.result_id not in associated_result_ids
+        ):
+            result_id = previous_result.result_id
+            associated_result_ids.add(result_id)
+            association_basis = "immediately_follows_result"
+            association_confidence = 0.8
+
+        proofs.append(
+            ProofEvidence(
+                proof_id=f"{paper_id}::proof:{len(proofs) + 1}",
+                paper_id=paper_id,
+                result_id=result_id,
+                text=proof.body,
+                span_indices=(span_index,),
+                association_basis=association_basis,
+                association_confidence=association_confidence,
+                method="latex_proof_environment",
+                confidence=1.0,
+            )
+        )
+
+    local_result_mentions = extract_local_result_mentions(
+        paper_id,
+        tuple(proofs),
+        tuple(results),
+    )
+    citation_mentions = extract_citation_mentions(
+        paper_id,
+        tuple(proofs),
+        (),
+    )
+    external_result_mentions = extract_external_result_mentions(
+        paper_id,
+        citation_mentions,
+    )
+
     return EvidenceDocument(
         paper_id=paper_id,
         source_type=source_type,
@@ -242,11 +382,11 @@ def latex_project_to_evidence_document(
         main_file=project.root_file.relative_to(project.project_root).as_posix(),
         spans=tuple(spans),
         results=tuple(results),
-        proofs=(),
+        proofs=tuple(proofs),
         bibliography_entries=(),
-        local_result_mentions=(),
-        citation_mentions=(),
-        external_result_mentions=(),
+        local_result_mentions=local_result_mentions,
+        citation_mentions=citation_mentions,
+        external_result_mentions=external_result_mentions,
         edges=(),
         warnings=(),
     )

--- a/src/papergraph/parser.py
+++ b/src/papergraph/parser.py
@@ -1,6 +1,6 @@
 import re
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 
 from papergraph.evidence import (
     EvidenceDocument,
@@ -201,12 +201,15 @@ def parse_latex_proofs(text: str) -> list[LatexProofBlock]:
     proofs: list[LatexProofBlock] = []
     for match in PROOF_ENVIRONMENT_RE.finditer(text):
         body = match.group("body")
+        stripped_body = body.strip()
+        leading_whitespace = len(body) - len(body.lstrip())
+        trailing_whitespace = len(body) - len(body.rstrip())
         proofs.append(
             LatexProofBlock(
                 position=match.start(),
-                body_start=match.start("body"),
-                body_end=match.end("body"),
-                body=body.strip(),
+                body_start=match.start("body") + leading_whitespace,
+                body_end=match.end("body") - trailing_whitespace,
+                body=stripped_body,
             )
         )
     return proofs
@@ -272,10 +275,6 @@ def latex_project_to_evidence_document(
             )
         )
 
-    proof_block_indices = {
-        proof.position: index
-        for index, proof in enumerate(proof_blocks)
-    }
     result_by_position = {
         node.position: result
         for node, result in zip(nodes, results)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.9.0\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.9.1\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(
@@ -74,11 +74,11 @@ def test_doctor_prints_json_without_starting_mcp(
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.9.0",
-            "release_tag": "v0.9.0",
+            "version": "0.9.1",
+            "release_tag": "v0.9.1",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.9.0"
+                "papergraph-mcp.git@v0.9.1"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -88,7 +88,7 @@ def test_doctor_prints_json_without_starting_mcp(
 
     server.main(["doctor"])
 
-    assert json.loads(capsys.readouterr().out)["version"] == "0.9.0"
+    assert json.loads(capsys.readouterr().out)["version"] == "0.9.1"
 
 
 def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,11 +5,11 @@ def test_environment_diagnostics_reports_version_and_release_source():
     result = environment_diagnostics()
 
     assert result["package_name"] == "papergraph-mcp"
-    assert result["version"] == "0.9.0"
-    assert result["release_tag"] == "v0.9.0"
+    assert result["version"] == "0.9.1"
+    assert result["release_tag"] == "v0.9.1"
     assert (
         result["recommended_source"]
-        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0"
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1"
     )
     assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
     assert isinstance(result["warnings"], list)
@@ -25,6 +25,6 @@ def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
 
     result = environment_diagnostics()
 
-    assert result["version"] == "0.9.0"
+    assert result["version"] == "0.9.1"
     assert result["git"] is None
     assert any("Git context unavailable" in warning for warning in result["warnings"])

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.0"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.1"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.9.0\n"
+        stdout = "papergraph-mcp 0.9.1\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.9.0"
+    assert result["version"] == "papergraph-mcp 0.9.1"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.9.0"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.9.1"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -361,4 +361,4 @@ def test_all_onboarding_source_pins_match_v090():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.9.0"}
+    assert set(refs) == {"v0.9.1"}

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -350,7 +350,7 @@ def test_readme_exposes_agent_guided_setup():
     assert ".agents/skills/setting-up-papergraph/SKILL.md" in text
 
 
-def test_all_onboarding_source_pins_match_v090():
+def test_all_onboarding_source_pins_match_v091():
     import re
 
     combined = "\n".join(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from papergraph.loader import load_latex_project
-from papergraph.parser import parse_project
+from papergraph.parser import latex_project_to_evidence_document, parse_project
 from papergraph.project import load_project
 
 
@@ -228,3 +228,126 @@ def test_load_project_deduplicates_bibliographies_and_repeated_includes(
         for span in shared_spans
     )
     assert project.bibliography_files == (bibliography.resolve(),)
+
+
+def test_latex_project_evidence_associates_adjacent_proof_environment(
+    tmp_path: Path,
+):
+    main = tmp_path / "main.tex"
+    main.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\begin{document}",
+                r"\begin{theorem}\label{th:main}",
+                "Main theorem.",
+                r"\end{theorem}",
+                r"\begin{proof}",
+                "The proof is direct.",
+                r"\end{proof}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    document = latex_project_to_evidence_document(
+        "local:paper",
+        "local",
+        str(main),
+        None,
+        load_project(main),
+    )
+
+    assert len(document.proofs) == 1
+    proof = document.proofs[0]
+    assert proof.result_id == "local:paper::th:main"
+    assert proof.association_basis == "immediately_follows_result"
+    assert proof.association_confidence == 0.8
+    assert proof.method == "latex_proof_environment"
+    assert proof.text == "The proof is direct."
+    assert document.spans[proof.span_indices[0]].source_type == "tex"
+
+
+def test_latex_project_evidence_leaves_repeated_adjacent_proof_unresolved(
+    tmp_path: Path,
+):
+    main = tmp_path / "main.tex"
+    main.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\begin{document}",
+                r"\begin{theorem}\label{th:main}",
+                "Main theorem.",
+                r"\end{theorem}",
+                r"\begin{proof}",
+                "First proof.",
+                r"\end{proof}",
+                r"\begin{proof}",
+                "Second proof should not steal the theorem.",
+                r"\end{proof}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    document = latex_project_to_evidence_document(
+        "local:paper",
+        "local",
+        str(main),
+        None,
+        load_project(main),
+    )
+
+    assert [proof.result_id for proof in document.proofs] == [
+        "local:paper::th:main",
+        None,
+    ]
+    assert document.proofs[1].association_basis == "unresolved"
+    assert document.proofs[1].association_confidence == 0.0
+
+
+def test_latex_project_evidence_extracts_proof_label_references(
+    tmp_path: Path,
+):
+    main = tmp_path / "main.tex"
+    main.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\newtheorem{lemma}{Lemma}",
+                r"\begin{document}",
+                r"\begin{lemma}\label{lem:base}",
+                "Base lemma.",
+                r"\end{lemma}",
+                r"\begin{theorem}\label{th:main}",
+                "Main theorem.",
+                r"\end{theorem}",
+                r"\begin{proof}",
+                r"By \cref{lem:base}.",
+                r"\end{proof}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    document = latex_project_to_evidence_document(
+        "local:paper",
+        "local",
+        str(main),
+        None,
+        load_project(main),
+    )
+
+    assert len(document.local_result_mentions) == 1
+    mention = document.local_result_mentions[0]
+    assert mention.raw_text == r"\cref{lem:base}"
+    assert mention.target_result_id == "local:paper::lem:base"
+    assert mention.resolution_status == "resolved_unique"
+    assert mention.method == "proof_latex_ref"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -267,7 +267,11 @@ def test_latex_project_evidence_associates_adjacent_proof_environment(
     assert proof.association_confidence == 0.8
     assert proof.method == "latex_proof_environment"
     assert proof.text == "The proof is direct."
-    assert document.spans[proof.span_indices[0]].source_type == "tex"
+    proof_span = document.spans[proof.span_indices[0]]
+    assert proof_span.source_type == "tex"
+    assert main.read_text(encoding="utf-8")[
+        proof_span.start_offset:proof_span.end_offset
+    ] == "The proof is direct."
 
 
 def test_latex_project_evidence_leaves_repeated_adjacent_proof_unresolved(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,7 +24,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.9.0"
+    assert project["version"] == "0.9.1"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -70,7 +70,7 @@ def test_lockfile_contains_project_package():
     )
 
     assert package["name"] == "papergraph-mcp"
-    assert package["version"] == "0.9.0"
+    assert package["version"] == "0.9.1"
 
 
 def test_validate_arxiv_request_module_stdout_is_json_only():
@@ -102,8 +102,8 @@ def test_runtime_and_issue_template_release_strings_remain_pinned():
         if item.get("id") == "version"
     )
 
-    assert f'PaperGraph/0.9.0 (+{REPOSITORY_URL})' in arxiv_source
-    assert version_field["attributes"]["placeholder"] == "0.9.0"
+    assert f'PaperGraph/0.9.1 (+{REPOSITORY_URL})' in arxiv_source
+    assert version_field["attributes"]["placeholder"] == "0.9.1"
 
 
 def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
@@ -144,7 +144,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.9.0" in build_steps
+    assert "papergraph-mcp 0.9.1" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -252,7 +252,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.9.0"
+        "papergraph-mcp.git@v0.9.1"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):
@@ -263,7 +263,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     )
     assert '"command": "uvx"' in readme
     assert pinned_source in readme
-    assert "PaperGraph v0.9.0" in readme
+    assert "PaperGraph v0.9.1" in readme
 
     for tool_name in (
         "load_paper",
@@ -315,6 +315,8 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
 
     assert "statement_explicit_latex_refs_only" in readme
     assert "not evidence that the theorem has no mathematical dependencies" in readme
+    assert "TeX proof environments" in readme
+    assert "immediately preceding result" in readme
     assert "raw_kind" in readme
     assert "display_kind" in readme
     assert "normalized_kind" in readme
@@ -394,8 +396,8 @@ def test_onboarding_uses_v061_release_pin_and_mentions_id_url_conflicts():
         ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
     ).read_text(encoding="utf-8")
 
-    assert "papergraph-mcp.git@v0.9.0" in skill
-    assert "papergraph-mcp 0.9.0" in skill
+    assert "papergraph-mcp.git@v0.9.1" in skill
+    assert "papergraph-mcp 0.9.1" in skill
     assert "validate_arxiv_request" in skill
     assert "load_arxiv_request" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,11 +169,11 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.9.0",
-            "release_tag": "v0.9.0",
+            "version": "0.9.1",
+            "release_tag": "v0.9.1",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.9.0"
+                "papergraph-mcp.git@v0.9.1"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -181,7 +181,7 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         },
     )
 
-    assert server.get_environment_diagnostics()["release_tag"] == "v0.9.0"
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.9.1"
 
 
 def test_validate_arxiv_input_tool_reports_conflict():

--- a/tests/test_workspace_evidence.py
+++ b/tests/test_workspace_evidence.py
@@ -350,6 +350,99 @@ def test_latex_import_populates_source_agnostic_results(workspace, loaded_projec
     assert results[0]["source_type"] == "local"
 
 
+def test_latex_import_populates_proof_dependencies(workspace, tmp_path: Path):
+    main = tmp_path / "main.tex"
+    main.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\newtheorem{lemma}{Lemma}",
+                r"\begin{document}",
+                r"\begin{lemma}\label{lem:base}",
+                "Base lemma.",
+                r"\end{lemma}",
+                r"\begin{theorem}\label{th:main}",
+                "Main theorem.",
+                r"\end{theorem}",
+                r"\begin{proof}",
+                r"By \cref{lem:base}.",
+                r"\end{proof}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    workspace.import_project("local:paper", "local", "main.tex", None, load_project(main))
+
+    proof = workspace.get_result_proof("local:paper::th:main")
+    dependencies = workspace.get_proof_dependencies(
+        "local:paper::th:main",
+        recursive=False,
+    )
+    path = workspace.get_result_reading_path("local:paper::th:main")
+
+    assert proof["known"]["proof"]["result_id"] == "local:paper::th:main"
+    assert proof["known"]["proof"]["method"] == "latex_proof_environment"
+    assert [
+        result["result_id"]
+        for result in dependencies["known"]["resolved_local_results"]
+    ] == ["local:paper::lem:base"]
+    assert path["edges"] == [
+        {
+            "source_result_id": "local:paper::th:main",
+            "target_result_id": "local:paper::lem:base",
+            "relation": "uses_local_result",
+        }
+    ]
+
+
+def test_latex_import_exposes_proof_external_result_stops(
+    workspace,
+    tmp_path: Path,
+):
+    main = tmp_path / "main.tex"
+    main.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\begin{document}",
+                r"\begin{theorem}\label{th:main}",
+                "Main theorem.",
+                r"\end{theorem}",
+                r"\begin{proof}",
+                "We apply [12, Theorem 3.5].",
+                r"\end{proof}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    workspace.import_project("local:paper", "local", "main.tex", None, load_project(main))
+
+    dependencies = workspace.get_proof_dependencies("local:paper::th:main")
+    path = workspace.get_result_reading_path("local:paper::th:main")
+
+    assert dependencies["unresolved"]["external_result_mentions"][0]["raw_text"] == (
+        "[12, Theorem 3.5]"
+    )
+    assert {
+        (
+            stop["result_id"],
+            stop["kind"],
+            stop["mentions"][0]["raw_text"],
+        )
+        for stop in path["unresolved_stops"]
+    } >= {
+        (
+            "local:paper::th:main",
+            "external_result_mentions",
+            "[12, Theorem 3.5]",
+        )
+    }
+
+
 def test_import_rejects_results_without_span_indices(tmp_path: Path):
     workspace = Workspace.open(tmp_path / "workspace.sqlite3")
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- add conservative TeX `proof` environment extraction for LaTeX project imports
- associate adjacent TeX proof blocks with the immediately preceding unassociated result
- resolve proof-local LaTeX label references such as `\cref{lem:base}` into local result dependencies
- expose proof-local external result stops from TeX proofs instead of silently losing them
- prepare v0.9.1 release pins, README, onboarding, and diagnostics

## Testing
- `uv run pytest`
- Result: `416 passed, 1 skipped in 35.15s`

## Notes
- No subagents were used.
- This patch intentionally does not implement roadmap extraction or citation-level import planning; those remain follow-up v0.9.x items.