### PR TITLE
Add Paper Map v0.10.0 overview

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -47,23 +47,23 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.9.3`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.10.0`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp --version
 ```
 
 The expected output is:
 
 ```text
-papergraph-mcp 0.9.3
+papergraph-mcp 0.10.0
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.9.3"
+      placeholder: "0.10.0"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.9.3"
+          test "$version" = "papergraph-mcp 0.10.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Read math papers with evidence, not guesses.**
 
-PaperGraph helps AI agents turn arXiv papers, local LaTeX projects, and born-digital PDFs into a theorem-centered reading workspace. It extracts results, proof evidence, citation stops, source slices, reading queues, reading sessions, and reviewable import plans so a researcher can inspect where every claim came from.
+PaperGraph helps AI agents turn arXiv papers, local LaTeX projects, and born-digital PDFs into a theorem-centered reading workspace. It extracts Paper Maps, results, proof evidence, citation stops, source slices, reading queues, reading sessions, and reviewable import plans so a researcher can inspect where every claim came from.
 
 [English](#english) | [中文](#中文)
 
@@ -21,11 +21,11 @@ PaperGraph helps AI agents turn arXiv papers, local LaTeX projects, and born-dig
 
 ### What PaperGraph Helps You Do
 
-| Extract the paper's structure | Trace proof evidence | Plan the next reading step |
+| Start with a Paper Map | Trace proof evidence | Plan the next reading step |
 | --- | --- | --- |
-| Find theorem-like results such as theorems, lemmas, propositions, definitions, and PDF-detected result blocks. | Inspect proof-local references, cited stops, source slices, and dependency diagnostics with explicit evidence. | Build reading queues, resume reading sessions, and review external arXiv import candidates before downloading anything. |
+| Identify main-result candidates, result structure, proof-path evidence, and external reading risks before choosing where to read. | Inspect proof-local references, cited stops, source slices, and dependency diagnostics with explicit evidence. | Build reading queues, resume reading sessions, and review external arXiv import candidates before downloading anything. |
 
-PaperGraph v0.9.3 adds review summaries to external import candidates. Before anything is downloaded, an agent can show which local result, proof, citation key, and cited result text justify importing a paper.
+PaperGraph v0.10.0 adds Paper Map, an evidence-first first-load overview for a paper. It highlights likely main-result candidates, local structure, proof-path evidence, and external reading risks without verifying proofs or guessing hidden dependencies.
 
 ### Why Researchers Use It
 
@@ -43,11 +43,11 @@ PaperGraph does not verify proofs, perform semantic theorem matching, or claim t
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the pinned GitHub release without cloning:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
-The pinned command becomes available after the `v0.9.3` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.10.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 Add PaperGraph to an MCP client that accepts JSON-style stdio configuration:
 
@@ -56,7 +56,7 @@ Add PaperGraph to an MCP client that accepts JSON-style stdio configuration:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0", "papergraph-mcp"]
     }
   }
 }
@@ -108,11 +108,11 @@ flowchart LR
 
 ### PaperGraph 能帮你做什么
 
-| 抽取论文结构 | 追踪证明证据 | 规划下一步阅读 |
+| 先看 Paper Map | 追踪证明证据 | 规划下一步阅读 |
 | --- | --- | --- |
-| 找出 theorem、lemma、proposition、definition 等 theorem-like results，也支持 born-digital PDF 中的结果块。 | 查看 proof-local references、citation stops、source slices 和 dependency diagnostics，并保留证据来源。 | 生成 reading queues、恢复 reading sessions，并在下载外部论文前生成可审阅的导入计划。 |
+| 在选择阅读目标前，先看到 main-result candidates、结果结构、proof-path evidence 和 external reading risks。 | 查看 proof-local references、citation stops、source slices 和 dependency diagnostics，并保留证据来源。 | 生成 reading queues、恢复 reading sessions，并在下载外部论文前生成可审阅的导入计划。 |
 
-v0.9.3 的重点是 external import review summaries：在下载外部论文之前，agent 可以先说明是哪一个本地结果、哪段 proof、哪个 citation key、哪段 cited result text 支持这次导入建议。
+v0.10.0 的重点是 Paper Map：加载论文后先生成 evidence-first 的首屏概览，帮助你看到可能的主结果、论文结构、证明路径证据和外部阅读风险，同时不验证证明、不猜隐藏依赖。
 
 ### 为什么适合数学论文阅读
 
@@ -130,7 +130,7 @@ PaperGraph does not verify proofs，也不做 semantic theorem matching；它不
 先安装 [uv](https://docs.astral.sh/uv/getting-started/installation/)，然后验证固定版本：
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
@@ -141,7 +141,7 @@ papergraph-mcp doctor
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0", "papergraph-mcp"]
     }
   }
 }
@@ -180,6 +180,7 @@ papergraph-mcp doctor
 | Workflow | Main tools |
 | --- | --- |
 | Load papers | `open_workspace`, `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_add_pdf_paper`, `workspace_list_papers`, `workspace_get_paper` |
+| Map a paper | `workspace_get_paper_map` |
 | Inspect results | `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_get_citations`, `workspace_search_theorems` |
 | Read a proof | `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path` |
 | Resume reading | `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary` |
@@ -188,7 +189,7 @@ papergraph-mcp doctor
 
 Original single-paper tools: `get_environment_diagnostics`, `validate_arxiv_request`, `load_arxiv_request`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`.
 
-Complete workspace tool index: `open_workspace`, `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_add_pdf_paper`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary`, `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, `workspace_apply_reading_queue_to_session`, `workspace_plan_external_imports_for_result`, `workspace_plan_external_imports_for_queue`, `workspace_plan_external_imports_for_paper`.
+Complete workspace tool index: `open_workspace`, `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_add_pdf_paper`, `workspace_get_paper_map`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary`, `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, `workspace_apply_reading_queue_to_session`, `workspace_plan_external_imports_for_result`, `workspace_plan_external_imports_for_queue`, `workspace_plan_external_imports_for_paper`.
 
 </details>
 
@@ -199,6 +200,7 @@ Most workspace operations are available from the CLI with `--workspace`:
 
 ```powershell
 papergraph-mcp validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609.01574)"
+papergraph-mcp --workspace .\papergraph.sqlite3 get-paper-map local:paper-a
 papergraph-mcp --workspace .\papergraph.sqlite3 export-reading-bundle local:paper-a
 papergraph-mcp --workspace .\papergraph.sqlite3 export-result-reading-context local:paper-a::thm:main
 papergraph-mcp --workspace .\papergraph.sqlite3 get-source-slice --result-id local:paper-a::thm:main
@@ -261,6 +263,7 @@ PDF extraction is best for born-digital PDFs; scanned PDFs or OCR-heavy files ma
 <details>
 <summary><strong>Release Highlights</strong></summary>
 
+- v0.10.0 added Paper Map, an evidence-first first-load overview with main-result candidates, structure, reading route, and external-risk evidence.
 - v0.9.3 added external import review summaries.
 - v0.9.2 improved cited-result mention extraction.
 - v0.9.1 added proof-adjacent dependency evidence.

--- a/docs/sessions/260908-185432-papergraph-v010-paper-map-roadmap.md
+++ b/docs/sessions/260908-185432-papergraph-v010-paper-map-roadmap.md
@@ -1,0 +1,115 @@
+The PaperGraph MCP project has reached v0.9.3 with external import review summaries, proof-roadmap extraction, proof-block association, reading queues, reading sessions, and local/PDF/arXiv evidence workflows in place.
+The user's latest strategic question was whether the project is close to a tool mathematical researchers truly need, and the answer was that PaperGraph now has the evidence database skeleton but still lacks a researcher-facing reading assistant layer.
+The most important proposed next feature is v0.10 Paper Map: a first-load overview that identifies main-result candidates, chapter/result structure, core proof path, external reading risks, and a recommended reading route.
+The user explicitly wants future work to stay evidence-first and not let agents guess mathematical dependencies, semantic theorem matches, or hidden prerequisites.
+README work was recently redesigned twice and merged to GitHub main, ending at `791a2a2 Merge researcher-focused README polish`, with the homepage now presenting PaperGraph as "Read math papers with evidence, not guesses."
+The current feature branch `feature/v0.9.3-external-citation-evidence` is clean and pushed at `d7892dc docs: make README researcher focused`, while `origin/main` is at `791a2a2`.
+Full validation after the final README polish passed with `424 passed, 1 skipped in 51.61s`, and the prior v0.9.3 code validation passed with `423 passed, 1 skipped`.
+The next conversation should begin from product planning for v0.10 Paper Map rather than another low-level extraction feature, because the main gap is organizing evidence into a researcher-readable paper overview.
+High-value follow-on gaps after Paper Map are dependency-role classification, notation/definition indexing, human-readable reading reports, cross-paper local literature graphs, and clearer evidence-quality status.
+The next agent should resume from this log, inspect the current `README.md`, `docs/superpowers/specs`, `docs/superpowers/plans`, and tests before writing a v0.10 spec, then implement without subagents if the user repeats that constraint.
+
+session: thread_id=01a06c45-21ff-77f2-b0f6-16c50bf24a56 save_seq=1 mode=full previous=none
+
+# Summary
+
+## Goal
+
+Create a dense conversation handoff package for the next chat, focused on the current PaperGraph MCP project state and the recommended next product direction.
+
+## Context
+
+- Repository: `D:\ai4math\papergraph-mcp`.
+- Active development worktree: `D:\ai4math\papergraph-mcp\.worktrees\feature-v0.9.3-external-citation-evidence`.
+- Current feature branch: `feature/v0.9.3-external-citation-evidence`.
+- Remote default branch: `origin/main`.
+- Latest remote main commit observed: `791a2a2 Merge researcher-focused README polish`.
+- Latest feature branch commit observed: `d7892dc docs: make README researcher focused`.
+- User works primarily in Chinese and prefers the agent to independently spec, implement, push, create PRs/releases, and publish once direction is approved; however, the user has repeatedly specified "do not use subagents" for feature work.
+
+## Key Decisions
+
+- The project's near-term problem is not more raw extraction alone; it is transforming existing evidence into a researcher-readable paper overview.
+- Recommended next feature: **v0.10 Paper Map**.
+- Paper Map should summarize a loaded paper's structure without claiming proof verification or semantic theorem matching.
+- Paper Map should prioritize:
+  - main-result candidates,
+  - section/chapter structure,
+  - result hierarchy,
+  - local proof path,
+  - external citation/import risk,
+  - recommended reading route,
+  - evidence-quality warnings.
+- Technical details should remain available but should not dominate first-use documentation or user-facing report surfaces.
+- The evidence-first contract is central: empty dependencies mean extraction limits, not absence of mathematical dependencies.
+
+## Work Performed
+
+- Earlier v0.9.3 work added external import candidate review summaries so agents can explain which local result, proof, citation key, and cited result text justify importing a cited paper before downloading.
+- README was first reorganized into a bilingual English/Chinese guide, then redesigned again into a researcher-focused project homepage.
+- The final README design now uses:
+  - centered GitHub-rendered title block,
+  - tagline: `Read math papers with evidence, not guesses.`,
+  - concise researcher-facing value explanation,
+  - English/Chinese anchors,
+  - capability tables,
+  - Mermaid reading-flow diagram,
+  - `What PaperGraph Does Not Do`,
+  - folded `Reference` sections for tool lists, CLI shortcuts, evidence boundaries, local walkthrough, safety/privacy, release highlights, and development.
+- Added a regression test: `test_readme_presents_researcher_focused_overview_before_reference`, which requires the README to expose a researcher-facing overview before dense reference material.
+- Merged the README polish into `main` and pushed it to GitHub.
+- Discussed remaining product gaps for mathematical researchers.
+
+## Files Changed
+
+- `README.md`
+  - Rewritten as a researcher-first bilingual README.
+  - Dense technical material moved into `<details>` reference blocks.
+- `tests/test_repository.py`
+  - Added `test_readme_presents_researcher_focused_overview_before_reference`.
+- `docs/superpowers/specs/2026-09-08-bilingual-readable-readme-design.md`
+  - Earlier README bilingual readability spec.
+- `docs/superpowers/plans/2026-09-08-bilingual-readable-readme.md`
+  - Earlier README bilingual implementation plan.
+- `docs/superpowers/specs/2026-09-08-researcher-focused-readme-design.md`
+  - Final researcher-focused README design spec.
+- `docs/superpowers/plans/2026-09-08-researcher-focused-readme.md`
+  - Final researcher-focused README implementation plan.
+
+## Validation
+
+- README/onboarding/local walkthrough tests passed after the final README polish:
+  - `40 passed in 3.21s`.
+- Full test suite passed on the feature branch after final README polish:
+  - `424 passed, 1 skipped in 44.82s`.
+- Full test suite passed on the merge-to-main candidate:
+  - `424 passed, 1 skipped in 51.61s`.
+- GitHub `main` was pushed from merge commit:
+  - `791a2a2 Merge researcher-focused README polish`.
+- Feature branch remained clean afterward:
+  - `feature/v0.9.3-external-citation-evidence...origin/feature/v0.9.3-external-citation-evidence`.
+
+## Open Questions / Next Steps
+
+- Start the next chat by designing **v0.10 Paper Map**.
+- Suggested v0.10 scope:
+  - create a new workspace-level or paper-level API such as `workspace_get_paper_map(paper_id: str) -> dict`;
+  - optionally add CLI export such as `papergraph-mcp --workspace ... export-paper-map PAPER_ID`;
+  - classify main-result candidates using explicit title/label/abstract/introduction/section evidence, not semantic truth claims;
+  - summarize section/result structure in deterministic source order;
+  - expose direct evidence for why a result is considered "main candidate," "supporting," or "technical," with uncertainty status;
+  - include reading-path highlights from existing proof dependency and reading queue machinery;
+  - include external import risks from v0.9.3 planner review summaries;
+  - add a human-readable report format that agents can show without dumping raw JSON.
+- Later roadmap candidates:
+  - dependency-role classifier: distinguish use as statement, method, estimate, construction, notation, or background;
+  - notation and definition index: locate where objects and assumptions are introduced and used;
+  - researcher-facing reading report: one-page human summary from evidence bundles;
+  - cross-paper local literature graph: minimal external reading set for understanding a target result;
+  - evidence-quality layer: clearer statuses for proof missing, PDF OCR risk, unresolved citation, inferred dependency, or unsupported semantic inference.
+- Preserve constraints:
+  - do not use subagents if the user repeats that requirement;
+  - write a spec before implementation;
+  - keep work evidence-first;
+  - run tests before claiming completion;
+  - avoid overwriting unrelated local changes or dirty worktrees.

--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -1,0 +1,5 @@
+# Session Log Index
+
+| Thread ID | Save Seq | Mode | Timestamp | Slug | Path | Summary |
+| --- | ---: | --- | --- | --- | --- | --- |
+| `01a06c45-21ff-77f2-b0f6-16c50bf24a56` | 1 | full | `260908-185432` | `papergraph-v010-paper-map-roadmap` | [260908-185432-papergraph-v010-paper-map-roadmap.md](260908-185432-papergraph-v010-paper-map-roadmap.md) | The PaperGraph MCP project has reached v0.9.3 with external import review summaries, proof-roadmap extraction, proof-block association, reading queues, reading sessions, and local/PDF/arXiv evidence workflows in place. |

--- a/docs/superpowers/plans/2026-09-10-paper-map-v0.10.md
+++ b/docs/superpowers/plans/2026-09-10-paper-map-v0.10.md
@@ -1,0 +1,936 @@
+# Paper Map v0.10 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not use subagents for this design or implementation flow.
+
+**Goal:** Build `v0.10.0` Paper Map: a read-only, evidence-first first-load overview for one stored paper.
+
+**Architecture:** Add a focused `src/papergraph/paper_map.py` module that assembles maps from existing workspace methods and small read-only SQL helpers. Keep `Workspace.get_paper_map()` thin, then expose it through MCP, CLI, README, and repository metadata. The feature must reuse stored evidence, reading paths, and external import plans; it must not add schema changes or new extraction logic.
+
+**Tech Stack:** Python 3.10+, SQLite through the existing `Workspace` connection, existing MCP server wrappers in `src/papergraph/server.py`, pytest, PyMuPDF test fixtures.
+
+## Global Constraints
+
+- Paper Map is evidence-first and must not infer hidden mathematical prerequisites.
+- Paper Map does not verify proofs.
+- Paper Map does not perform semantic theorem matching.
+- Paper Map does not automatically import external papers.
+- Paper Map does not call the live arXiv API, DOI services, Crossref, Semantic Scholar, or web search.
+- Paper Map is read-only and must not create reading queues, reading sessions, import records, or schema migrations.
+- `max_candidates` must be an integer between `1` and `20`.
+- Output order must be deterministic.
+- Release version for this feature is `v0.10.0`.
+- Execute this plan inline; do not dispatch subagents.
+
+---
+
+## File Structure
+
+- Create `src/papergraph/paper_map.py`
+  - Owns the Paper Map assembly logic, candidate scoring, route conversion, evidence-quality warnings, and source-order helpers.
+- Modify `src/papergraph/workspace.py`
+  - Imports `build_paper_map`.
+  - Adds thin read-only `Workspace.get_paper_map(paper_id: str, max_candidates: int = 5) -> dict`.
+- Modify `src/papergraph/server.py`
+  - Adds MCP wrapper `workspace_get_paper_map`.
+  - Adds CLI parser and dispatch for `get-paper-map`.
+- Create `tests/test_workspace_paper_map.py`
+  - Tests workspace-level map payload, candidate scoring, warnings, route, and external risks.
+- Create `tests/test_workspace_paper_map_server.py`
+  - Tests MCP wrapper success and error conversion.
+- Create `tests/test_cli_paper_map.py`
+  - Tests CLI JSON output and invalid input errors.
+- Modify `tests/test_repository.py`
+  - Updates version/tool/README expectations for `0.10.0`.
+- Modify `tests/test_onboarding.py`
+  - Updates release pin expectations to `v0.10.0`.
+- Modify `README.md`, `pyproject.toml`, `uv.lock`, `src/papergraph/arxiv.py`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `.agents/skills/setting-up-papergraph/SKILL.md`, `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+  - Updates docs and version pins consistently.
+
+---
+
+### Task 1: Core Paper Map Workspace API
+
+**Files:**
+- Create: `src/papergraph/paper_map.py`
+- Modify: `src/papergraph/workspace.py`
+- Test: `tests/test_workspace_paper_map.py`
+
+**Interfaces:**
+- Consumes:
+  - `Workspace.get_paper(paper_id: str) -> dict`
+  - `Workspace.list_results(paper_id: str | None = None, kind: str | None = None, limit: int = 50) -> list[dict]`
+  - `Workspace.get_result(result_id: str) -> dict`
+  - `Workspace.get_result_proof(result_id: str) -> dict`
+  - `Workspace.get_result_reading_path(result_id: str, recursive: bool = True) -> dict`
+  - `Workspace.plan_external_imports_for_paper(paper_id: str) -> dict`
+  - `workspace._connection` for read-only counts and unbounded result rows
+- Produces:
+  - `papergraph.paper_map.build_paper_map(workspace: Workspace, paper_id: str, max_candidates: int = 5) -> dict`
+  - `Workspace.get_paper_map(self, paper_id: str, max_candidates: int = 5) -> dict`
+
+- [ ] **Step 1: Write failing workspace tests**
+
+Create `tests/test_workspace_paper_map.py`:
+
+```python
+from pathlib import Path
+
+import fitz
+import pytest
+
+from papergraph.workspace import Workspace
+
+
+def write_paper_map_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Introduction",
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2, Lemma 9.9, and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def import_paper_map_pdf(workspace: Workspace, tmp_path: Path) -> str:
+    pdf = tmp_path / "paper-map.pdf"
+    write_paper_map_pdf(pdf)
+    workspace.import_pdf(pdf, "local:paper")
+    return "local:paper::pdf:theorem:1.1"
+
+
+def test_paper_map_returns_researcher_overview(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        result_id = import_paper_map_pdf(workspace, tmp_path)
+
+        paper_map = workspace.get_paper_map("local:paper")
+
+        assert paper_map["map_schema_version"] == 1
+        assert paper_map["paper"]["paper_id"] == "local:paper"
+        assert paper_map["paper"]["result_count"] == 2
+        assert paper_map["paper"]["proof_count"] == 2
+        assert paper_map["summary"]["recommended_start_result_id"] == result_id
+        assert paper_map["summary"]["main_candidate_count"] >= 1
+        assert paper_map["summary"]["external_risk_count"] == 1
+        assert paper_map["summary"]["unresolved_risk_count"] == 1
+        assert paper_map["summary"]["evidence_status"] == "usable"
+        candidate = paper_map["main_result_candidates"][0]
+        assert candidate["result_id"] == result_id
+        assert candidate["display_kind"] == "theorem"
+        assert candidate["status"] == "candidate"
+        assert candidate["statement_preview"]
+        assert {reason["kind"] for reason in candidate["reasons"]} >= {
+            "title_signal",
+            "early_theorem_signal",
+            "proof_dependency_signal",
+            "citation_risk_signal",
+        }
+        assert candidate["reading_path"]["local_result_count"] == 2
+        assert candidate["reading_path"]["external_stop_count"] == 1
+        assert candidate["reading_path"]["unresolved_stop_count"] == 1
+        assert paper_map["structure"]["result_order"] == [
+            "local:paper::pdf:lemma:1.2",
+            "local:paper::pdf:theorem:1.1",
+        ]
+        assert paper_map["reading_route"][0]["target_id"] == result_id
+        assert paper_map["reading_route"][0]["priority"] == "start"
+        assert any(
+            item["target_kind"] == "external_stop"
+            and item["priority"] == "caution"
+            for item in paper_map["reading_route"]
+        )
+        assert paper_map["external_risks"]["candidates"][0]["review"][
+            "citation_keys"
+        ] == ["12"]
+        assert "Paper Map does not verify proofs." in paper_map[
+            "evidence_quality"
+        ]["boundaries"]
+    finally:
+        workspace.close()
+
+
+def test_paper_map_respects_max_candidates(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_paper_map_pdf(workspace, tmp_path)
+
+        paper_map = workspace.get_paper_map("local:paper", max_candidates=1)
+
+        assert len(paper_map["main_result_candidates"]) == 1
+    finally:
+        workspace.close()
+
+
+def test_paper_map_reports_limited_empty_paper(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        workspace._connection.execute(
+            """
+            INSERT INTO papers (
+                paper_id, source_type, source_ref, source_version, title,
+                authors_json, main_file, imported_at, parser_version
+            ) VALUES (
+                'local:empty', 'pdf', 'empty.pdf', NULL, NULL,
+                '[]', NULL, '2026-09-10T00:00:00+00:00', 'test'
+            )
+            """
+        )
+        workspace._connection.commit()
+
+        paper_map = workspace.get_paper_map("local:empty")
+
+        assert paper_map["main_result_candidates"] == []
+        assert paper_map["summary"]["recommended_start_result_id"] is None
+        assert paper_map["summary"]["evidence_status"] == "limited"
+        assert paper_map["evidence_quality"]["warnings"][0]["kind"] == "no_results"
+    finally:
+        workspace.close()
+
+
+def test_paper_map_rejects_invalid_max_candidates(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_paper_map_pdf(workspace, tmp_path)
+
+        with pytest.raises(ValueError, match="max_candidates must be an integer"):
+            workspace.get_paper_map("local:paper", max_candidates=True)
+        with pytest.raises(ValueError, match="max_candidates must be between 1 and 20"):
+            workspace.get_paper_map("local:paper", max_candidates=0)
+        with pytest.raises(ValueError, match="max_candidates must be between 1 and 20"):
+            workspace.get_paper_map("local:paper", max_candidates=21)
+    finally:
+        workspace.close()
+
+
+def test_paper_map_rejects_unknown_paper(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        with pytest.raises(KeyError, match="Unknown paper id"):
+            workspace.get_paper_map("local:missing")
+    finally:
+        workspace.close()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_paper_map.py -q -p no:cacheprovider
+```
+
+Expected: failure because `Workspace.get_paper_map` does not exist.
+
+- [ ] **Step 3: Implement `paper_map.py`**
+
+Create `src/papergraph/paper_map.py` with these functions and constants:
+
+```python
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from papergraph.identity import normalize_paper_id
+
+if TYPE_CHECKING:
+    from papergraph.workspace import Workspace
+
+
+MAIN_RESULT_KINDS = {
+    "theorem",
+    "proposition",
+    "corollary",
+    "lemma",
+    "definition",
+}
+WARNING_ORDER = {
+    "no_results": 0,
+    "no_main_candidate": 1,
+    "missing_proof": 2,
+    "external_dependencies": 3,
+    "unresolved_references": 4,
+    "sparse_pdf_text": 5,
+}
+
+
+def build_paper_map(
+    workspace: Workspace,
+    paper_id: str,
+    max_candidates: int = 5,
+) -> dict[str, Any]:
+    max_candidates = _validate_max_candidates(max_candidates)
+    normalized_paper_id = normalize_paper_id(paper_id)
+    paper = workspace.get_paper(normalized_paper_id)
+    results = _list_all_results(workspace, normalized_paper_id)
+    proofs_by_result = {
+        result["result_id"]: workspace.get_result_proof(result["result_id"])
+        for result in results
+    }
+    candidates = _main_result_candidates(
+        workspace,
+        results,
+        proofs_by_result,
+        max_candidates,
+    )
+    recommended_start = (
+        candidates[0]["result_id"]
+        if candidates
+        else None
+    )
+    reading_route = (
+        _reading_route(workspace, recommended_start)
+        if recommended_start
+        else []
+    )
+    external_risks = workspace.plan_external_imports_for_paper(normalized_paper_id)
+    evidence_quality = _evidence_quality(
+        paper,
+        results,
+        candidates,
+        proofs_by_result,
+        reading_route,
+        external_risks,
+    )
+    structure = _structure(results)
+    proof_count = _count_rows(workspace, "proofs", normalized_paper_id)
+    citation_count = _count_rows(workspace, "citation_mentions", normalized_paper_id)
+    return {
+        "map_schema_version": 1,
+        "paper": {
+            "paper_id": paper["paper_id"],
+            "source_type": paper["source_type"],
+            "title": paper.get("title"),
+            "arxiv_id": paper.get("source_ref")
+            if paper.get("source_type") == "arxiv"
+            else None,
+            "result_count": len(results),
+            "proof_count": proof_count,
+            "citation_count": citation_count,
+        },
+        "summary": {
+            "main_candidate_count": len(candidates),
+            "section_count": len(structure["sections"]),
+            "external_risk_count": external_risks["summary"][
+                "import_candidate_count"
+            ],
+            "unresolved_risk_count": external_risks["summary"]["blocked_count"],
+            "recommended_start_result_id": recommended_start,
+            "evidence_status": evidence_quality["status"],
+        },
+        "main_result_candidates": candidates,
+        "structure": structure,
+        "reading_route": reading_route,
+        "external_risks": external_risks,
+        "evidence_quality": evidence_quality,
+    }
+```
+
+Continue the file with these helper signatures:
+
+```python
+def _validate_max_candidates(value: int) -> int: ...
+def _list_all_results(workspace: Workspace, paper_id: str) -> list[dict[str, Any]]: ...
+def _result_sort_key(result: dict[str, Any]) -> tuple[int, str]: ...
+def _main_result_candidates(workspace: Workspace, results: list[dict[str, Any]], proofs_by_result: dict[str, dict[str, Any]], max_candidates: int) -> list[dict[str, Any]]: ...
+def _candidate_for_result(workspace: Workspace, result: dict[str, Any], index: int, proofs_by_result: dict[str, dict[str, Any]]) -> dict[str, Any] | None: ...
+def _candidate_reasons(result: dict[str, Any], index: int, path: dict[str, Any]) -> list[dict[str, Any]]: ...
+def _reading_path_summary(path: dict[str, Any]) -> dict[str, Any]: ...
+def _reading_route(workspace: Workspace, result_id: str) -> list[dict[str, Any]]: ...
+def _structure(results: list[dict[str, Any]]) -> dict[str, Any]: ...
+def _evidence_quality(paper: dict[str, Any], results: list[dict[str, Any]], candidates: list[dict[str, Any]], proofs_by_result: dict[str, dict[str, Any]], reading_route: list[dict[str, Any]], external_risks: dict[str, Any]) -> dict[str, Any]: ...
+def _count_rows(workspace: Workspace, table: str, paper_id: str) -> int: ...
+def _statement_preview(statement: str | None, limit: int = 160) -> str: ...
+```
+
+Use these concrete helper rules:
+
+```python
+def _validate_max_candidates(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("max_candidates must be an integer")
+    if not 1 <= value <= 20:
+        raise ValueError("max_candidates must be between 1 and 20")
+    return value
+
+
+def _statement_preview(statement: str | None, limit: int = 160) -> str:
+    compact = " ".join((statement or "").split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3].rstrip() + "..."
+```
+
+For `_list_all_results`, query `results` joined to `papers` with no `LIMIT`, serialize with the same fields exposed by `list_results`, and attach `first_location` through `workspace._first_result_location(row[0])`. Order by `source_spans.start_line`, `source_spans.start_offset`, then `results.result_id` using a left join, falling back to `results.result_id` when no span exists.
+
+For candidate scoring:
+
+```python
+def _candidate_reasons(result: dict[str, Any], index: int, path: dict[str, Any]) -> list[dict[str, Any]]:
+    text = " ".join(
+        str(result.get(key) or "")
+        for key in ("label", "title", "visible_number", "statement")
+    ).lower()
+    reasons = []
+    if any(token in text for token in ("main", "principal", "main theorem", "main result")):
+        reasons.append({"kind": "title_signal", "weight": 4, "evidence": "result text contains a main-result cue"})
+    if result.get("label") and any(token in str(result["label"]).lower() for token in ("main", "principal", "mainthm", "main-theorem")):
+        reasons.append({"kind": "label_signal", "weight": 4, "evidence": f"label {result['label']!r} contains a main-result cue"})
+    if index < 3 and (result.get("normalized_kind") or result.get("display_kind")) in {"theorem", "proposition", "corollary", "lemma"}:
+        reasons.append({"kind": "early_theorem_signal", "weight": 2, "evidence": "result appears among the first theorem-like records"})
+    if path["top_down"]:
+        reasons.append({"kind": "proof_dependency_signal", "weight": 1, "evidence": "reading path evidence is available"})
+    if path["external_stops"]:
+        reasons.append({"kind": "citation_risk_signal", "weight": 1, "evidence": "reading path includes external stops"})
+    return reasons
+```
+
+Candidate `score` is the sum of `weight`. Drop zero-score candidates unless there are results and all candidates have zero score; in that case keep the first eligible result with `status: "candidate"` and a `early_theorem_signal` reason so the map has a starting point. Add `no_main_candidate` warning in evidence quality when the top candidate was only fallback.
+
+For `_reading_route`, convert path entries to route items with stable target kinds:
+
+```python
+route = [{
+    "position": 1,
+    "target_kind": "result_id",
+    "target_id": result_id,
+    "priority": "start",
+    "reason": "selected_main_candidate",
+    "evidence": {"source": "paper_map.main_result_candidates"},
+}]
+```
+
+Then append proof, local dependency result IDs, external stops, and unresolved stops in reading-path order. Keep no more than 20 route items.
+
+- [ ] **Step 4: Add `Workspace.get_paper_map`**
+
+Modify `src/papergraph/workspace.py` imports near the other local imports:
+
+```python
+from papergraph.paper_map import build_paper_map
+```
+
+Add this method after `plan_external_imports_for_paper`:
+
+```python
+    @_synchronized
+    def get_paper_map(self, paper_id: str, max_candidates: int = 5) -> dict:
+        """Return an evidence-first first-load map for one stored paper."""
+
+        return build_paper_map(
+            self,
+            paper_id,
+            max_candidates=max_candidates,
+        )
+```
+
+- [ ] **Step 5: Run workspace tests**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_paper_map.py -q -p no:cacheprovider
+```
+
+Expected: all tests in `tests/test_workspace_paper_map.py` pass.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/papergraph/paper_map.py src/papergraph/workspace.py tests/test_workspace_paper_map.py
+git commit -m "feat: add paper map workspace API"
+```
+
+---
+
+### Task 2: MCP Tool Wrapper
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Test: `tests/test_workspace_paper_map_server.py`
+
+**Interfaces:**
+- Consumes: `Workspace.get_paper_map(paper_id: str, max_candidates: int = 5) -> dict`
+- Produces: `workspace_get_paper_map(paper_id: str, max_candidates: int = 5) -> dict`
+
+- [ ] **Step 1: Write failing MCP tests**
+
+Create `tests/test_workspace_paper_map_server.py`:
+
+```python
+from pathlib import Path
+
+import fitz
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+
+import papergraph.server as server
+
+
+def write_paper_map_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    server._reset_server_state()
+    yield
+    server._reset_server_state()
+
+
+def load_workspace(tmp_path: Path) -> None:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_paper_map_pdf(pdf)
+    server.open_workspace(str(workspace_path))
+    server.workspace_add_pdf_paper(str(pdf), "local:paper")
+
+
+def test_paper_map_mcp_tool_returns_payload(tmp_path: Path):
+    load_workspace(tmp_path)
+
+    paper_map = server.workspace_get_paper_map("local:paper", max_candidates=1)
+
+    assert paper_map["map_schema_version"] == 1
+    assert paper_map["paper"]["paper_id"] == "local:paper"
+    assert len(paper_map["main_result_candidates"]) == 1
+    assert paper_map["external_risks"]["summary"]["import_candidate_count"] == 1
+
+
+def test_paper_map_mcp_tool_reports_missing_workspace():
+    with pytest.raises(ToolError, match="open_workspace"):
+        server.workspace_get_paper_map("local:paper")
+
+
+def test_paper_map_mcp_tool_converts_workspace_errors(tmp_path: Path):
+    server.open_workspace(str(tmp_path / "workspace.sqlite3"))
+
+    with pytest.raises(ToolError, match="Unknown paper id"):
+        server.workspace_get_paper_map("local:missing")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_paper_map_server.py -q -p no:cacheprovider
+```
+
+Expected: failure because `workspace_get_paper_map` does not exist.
+
+- [ ] **Step 3: Add MCP wrapper**
+
+In `src/papergraph/server.py`, insert after `workspace_plan_external_imports_for_paper`:
+
+```python
+@mcp.tool()
+@_serialized_workspace_tool
+def workspace_get_paper_map(
+    paper_id: str,
+    max_candidates: int = 5,
+) -> dict:
+    """Return an evidence-first first-load map for one stored paper."""
+
+    try:
+        return require_workspace().get_paper_map(
+            paper_id,
+            max_candidates=max_candidates,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+```
+
+- [ ] **Step 4: Run MCP tests**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_paper_map_server.py -q -p no:cacheprovider
+```
+
+Expected: all tests in `tests/test_workspace_paper_map_server.py` pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_workspace_paper_map_server.py
+git commit -m "feat: expose paper map MCP tool"
+```
+
+---
+
+### Task 3: CLI Command
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Test: `tests/test_cli_paper_map.py`
+
+**Interfaces:**
+- Consumes: `Workspace.get_paper_map(paper_id: str, max_candidates: int = 5) -> dict`
+- Produces: CLI command `get-paper-map`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Create `tests/test_cli_paper_map.py`:
+
+```python
+import json
+from pathlib import Path
+
+import fitz
+import pytest
+
+import papergraph.server as server
+from papergraph.workspace import Workspace
+
+
+def write_paper_map_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def create_paper_map_workspace(tmp_path: Path) -> Path:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_paper_map_pdf(pdf)
+    workspace = Workspace.open(workspace_path)
+    try:
+        workspace.import_pdf(pdf, "local:paper")
+    finally:
+        workspace.close()
+    return workspace_path
+
+
+def read_json(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_get_paper_map_cli_prints_json(tmp_path: Path, capsys):
+    workspace_path = create_paper_map_workspace(tmp_path)
+
+    server.main(
+        [
+            "get-paper-map",
+            "--workspace",
+            str(workspace_path),
+            "--paper-id",
+            "local:paper",
+            "--max-candidates",
+            "1",
+        ]
+    )
+
+    payload = read_json(capsys)
+    assert payload["map_schema_version"] == 1
+    assert payload["paper"]["paper_id"] == "local:paper"
+    assert len(payload["main_result_candidates"]) == 1
+
+
+def test_get_paper_map_cli_reports_unknown_paper(tmp_path: Path, capsys):
+    workspace_path = create_paper_map_workspace(tmp_path)
+
+    with pytest.raises(SystemExit) as caught:
+        server.main(
+            [
+                "get-paper-map",
+                "--workspace",
+                str(workspace_path),
+                "--paper-id",
+                "local:missing",
+            ]
+        )
+
+    assert caught.value.code == 1
+    payload = read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["command"] == "get-paper-map"
+    assert "Unknown paper id" in payload["message"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```powershell
+uv run pytest tests/test_cli_paper_map.py -q -p no:cacheprovider
+```
+
+Expected: failure because the parser does not know `get-paper-map`.
+
+- [ ] **Step 3: Add CLI parser and dispatch**
+
+In `src/papergraph/server.py`, add parser setup after `plan-external-imports-for-paper`:
+
+```python
+    paper_map_parser = subparsers.add_parser(
+        "get-paper-map",
+        help="Return an evidence-first first-load map for one stored paper.",
+    )
+    paper_map_parser.add_argument("--workspace", required=True)
+    paper_map_parser.add_argument("--paper-id", required=True)
+    paper_map_parser.add_argument("--max-candidates", type=int, default=5)
+```
+
+Add dispatch after `plan-external-imports-for-paper` dispatch:
+
+```python
+    if args.command == "get-paper-map":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.get_paper_map(
+                args.paper_id,
+                max_candidates=args.max_candidates,
+            ),
+        )
+        return
+```
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```powershell
+uv run pytest tests/test_cli_paper_map.py -q -p no:cacheprovider
+```
+
+Expected: all tests in `tests/test_cli_paper_map.py` pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_cli_paper_map.py
+git commit -m "feat: add paper map CLI"
+```
+
+---
+
+### Task 4: Documentation, Version Pins, And Repository Tests
+
+**Files:**
+- Modify: `README.md`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `.agents/skills/setting-up-papergraph/SKILL.md`
+- Modify: `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+- Modify: `tests/test_repository.py`
+- Modify: `tests/test_onboarding.py`
+
+**Interfaces:**
+- Consumes: public names `workspace_get_paper_map` and `get-paper-map`
+- Produces: docs and metadata consistently pinned to `0.10.0` / `v0.10.0`
+
+- [ ] **Step 1: Update failing repository tests first**
+
+Modify `tests/test_repository.py`:
+
+```python
+assert project["version"] == "0.10.0"
+assert package["version"] == "0.10.0"
+assert f'PaperGraph/0.10.0 (+{REPOSITORY_URL})' in arxiv_source
+assert version_field["attributes"]["placeholder"] == "0.10.0"
+assert "papergraph-mcp 0.10.0" in build_steps
+```
+
+In `test_readme_is_a_version_pinned_launch_page_with_verified_demo`, set:
+
+```python
+pinned_source = (
+    "git+https://github.com/lotchuazzz-crypto/"
+    "papergraph-mcp.git@v0.10.0"
+)
+assert "PaperGraph v0.10.0" in readme
+```
+
+Add `workspace_get_paper_map` to the workspace tool loop, and add:
+
+```python
+assert "get-paper-map" in readme
+assert "Paper Map" in readme
+```
+
+Modify `tests/test_onboarding.py`:
+
+```python
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0"
+assert "papergraph-mcp.git@v0.10.0" in skill
+assert "papergraph-mcp 0.10.0" in skill
+assert result["version"] == "papergraph-mcp 0.10.0"
+stdout = "papergraph-mcp 0.10.0\n"
+assert set(refs) == {"v0.10.0"}
+```
+
+Rename `test_all_onboarding_source_pins_match_v093` to `test_all_onboarding_source_pins_match_v0100`.
+
+- [ ] **Step 2: Run repository tests to verify they fail**
+
+Run:
+
+```powershell
+uv run pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: failures for old docs/version pins.
+
+- [ ] **Step 3: Update metadata and docs**
+
+Make these exact version replacements:
+
+```powershell
+0.9.3 -> 0.10.0
+v0.9.3 -> v0.10.0
+```
+
+Apply them only in release/version/pin contexts in:
+
+- `pyproject.toml`
+- `uv.lock`
+- `src/papergraph/arxiv.py`
+- `.github/ISSUE_TEMPLATE/bug_report.yml`
+- `.agents/skills/setting-up-papergraph/SKILL.md`
+- `.agents/skills/setting-up-papergraph/references/client-configuration.md`
+
+Update `README.md`:
+
+- In "What PaperGraph Helps You Do", add Paper Map as the first capability phrase: "Start with a Paper Map that identifies main-result candidates, result structure, proof-path evidence, and external reading risks."
+- In the tool reference, add `workspace_get_paper_map` to the complete workspace tool index.
+- In CLI shortcuts, add:
+
+```powershell
+papergraph-mcp --workspace .\papergraph.sqlite3 get-paper-map local:paper-a
+```
+
+- In release highlights, add:
+
+```markdown
+- v0.10.0 added Paper Map, an evidence-first first-load overview with main-result candidates, structure, reading route, and external-risk evidence.
+```
+
+- Keep "What PaperGraph Does Not Do" unchanged in spirit: it must still say PaperGraph does not verify proofs, guess hidden prerequisites, or automatically crawl literature.
+
+- [ ] **Step 4: Run repository tests**
+
+Run:
+
+```powershell
+uv run pytest tests/test_repository.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: all selected repository/onboarding tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add README.md pyproject.toml uv.lock src/papergraph/arxiv.py .github/ISSUE_TEMPLATE/bug_report.yml .agents/skills/setting-up-papergraph/SKILL.md .agents/skills/setting-up-papergraph/references/client-configuration.md tests/test_repository.py tests/test_onboarding.py
+git commit -m "docs: document paper map v0.10"
+```
+
+---
+
+### Task 5: Full Validation And Polish
+
+**Files:**
+- Modify only files needed to fix failures found by the selected and full test runs.
+
+**Interfaces:**
+- Consumes: all public APIs added above
+- Produces: a clean branch with all tests passing
+
+- [ ] **Step 1: Run all focused Paper Map tests**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_paper_map.py tests/test_workspace_paper_map_server.py tests/test_cli_paper_map.py -q -p no:cacheprovider
+```
+
+Expected: all focused Paper Map tests pass.
+
+- [ ] **Step 2: Run nearby regression tests**
+
+Run:
+
+```powershell
+uv run pytest tests/test_workspace_reading.py tests/test_workspace_reading_queue.py tests/test_workspace_external_import_planner.py tests/test_workspace_external_import_planner_server.py tests/test_cli_external_import_planner.py -q -p no:cacheprovider
+```
+
+Expected: all selected reading/import planner tests pass.
+
+- [ ] **Step 3: Run full suite**
+
+Run:
+
+```powershell
+uv run pytest -q -p no:cacheprovider
+```
+
+Expected: full suite passes.
+
+- [ ] **Step 4: Inspect git status and recent commits**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --oneline -5
+```
+
+Expected: branch contains the Paper Map implementation commits and no unstaged changes.
+
+- [ ] **Step 5: Commit any final fixes**
+
+If Step 1, Step 2, or Step 3 required fixes, commit only those final fixes:
+
+```powershell
+git add <changed-files>
+git commit -m "test: stabilize paper map v0.10"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: Tasks cover workspace API, MCP, CLI, docs, version pins, tests, evidence-quality warnings, external risks, deterministic candidate ordering, and full validation.
+- Placeholder scan: This plan contains no unresolved placeholder sections and no implementation-free "write tests" steps.
+- Type consistency: Public names are stable across tasks: `build_paper_map`, `Workspace.get_paper_map`, `workspace_get_paper_map`, and `get-paper-map`.
+- Constraint check: The plan is read-only for map generation, avoids schema changes, avoids network calls, avoids semantic matching, avoids proof verification, and explicitly forbids subagents.

--- a/docs/superpowers/specs/2026-09-10-paper-map-v0.10-design.md
+++ b/docs/superpowers/specs/2026-09-10-paper-map-v0.10-design.md
@@ -1,0 +1,432 @@
+# Paper Map v0.10 Design
+
+## Purpose
+
+PaperGraph v0.9.3 has the core evidence database pieces a researcher needs: paper ingestion, theorem-like result extraction, proof evidence, proof-local dependency paths, reading queues, reading sessions, citation evidence, and reviewable external import plans. The next gap is first-load orientation.
+
+v0.10 adds **Paper Map**: a deterministic, evidence-first overview of one loaded paper. Paper Map should answer the first researcher question after loading a paper:
+
+> What is this paper's result structure, where are the likely main results, what proof path should I inspect first, and what external reading risks are visible from stored evidence?
+
+Paper Map is not a new mathematical reasoner. It organizes existing stored evidence into a researcher-readable map with explicit confidence and source traces.
+
+## Product Goal
+
+When a researcher or agent calls Paper Map for a paper, the response should be immediately useful as a reading plan:
+
+- identify main-result candidates without claiming mathematical importance as fact;
+- show section and result structure in source order;
+- show local proof paths for selected candidate results when evidence exists;
+- surface external citation/import risks before any download;
+- recommend a bounded reading route through the current paper;
+- explain evidence quality and extraction limits in plain terms.
+
+The feature should make PaperGraph feel like a paper-reading assistant rather than a collection of low-level extraction commands, while preserving the project's evidence-first contract.
+
+## Users
+
+- A mathematical researcher who just loaded a paper and wants a first-pass map before choosing a theorem to read.
+- A coding or research agent that needs a compact overview to decide which existing PaperGraph tool to call next.
+- A local literature-workspace maintainer who wants to see whether a paper is blocked by unresolved or external references.
+
+## Design Principles
+
+- **Evidence first:** every nontrivial classification includes source evidence or an explicit reason that the evidence is missing.
+- **No semantic theorem matching:** Paper Map does not decide that two results are equivalent, nor does it infer hidden prerequisites.
+- **No proof verification:** it reports proof evidence and dependency traces; it does not validate arguments.
+- **Deterministic output:** identical workspace content produces identical IDs, ordering, and summaries.
+- **Readability over exhaustiveness:** the map highlights the first useful reading route, with links back to existing detailed tools for deeper inspection.
+- **Additive API:** v0.10 adds read-only APIs and CLI output without changing existing schemas or mutating workspaces.
+
+## Scope
+
+### In Scope
+
+- Add a workspace-level Paper Map API for one paper:
+
+```python
+def get_paper_map(self, paper_id: str, max_candidates: int = 5) -> dict: ...
+```
+
+- Add MCP tool:
+
+```python
+workspace_get_paper_map(paper_id: str, max_candidates: int = 5) -> dict
+```
+
+- Add CLI command:
+
+```powershell
+papergraph-mcp --workspace .\papergraph.sqlite3 get-paper-map local:paper-a
+papergraph-mcp --workspace .\papergraph.sqlite3 get-paper-map local:paper-a --max-candidates 3
+```
+
+- Build the map from existing workspace data:
+  - paper metadata;
+  - result records;
+  - source spans;
+  - proof records;
+  - proof dependencies;
+  - reading paths;
+  - citation evidence;
+  - external import planner output.
+- Classify main-result candidates with explicit heuristic evidence.
+- Provide section/result structure in source order.
+- Provide reading-route recommendations for candidate results.
+- Include external import risks using existing import planner review summaries.
+- Include evidence-quality warnings and capability boundaries.
+- Update README/tool tables and release pins for `v0.10.0`.
+
+### Out of Scope
+
+- New PDF, TeX, or citation extraction logic.
+- Automatic external paper import.
+- Live arXiv calls during map generation.
+- DOI/Crossref/Semantic Scholar/web search.
+- Semantic theorem matching.
+- LLM-generated summaries.
+- Persistent database schema changes.
+- A graphical UI.
+- Ranking results by true mathematical importance.
+
+## Public API
+
+### Workspace API
+
+Add to `Workspace`:
+
+```python
+def get_paper_map(self, paper_id: str, max_candidates: int = 5) -> dict:
+    ...
+```
+
+Validation rules:
+
+- Unknown `paper_id` raises `KeyError`.
+- `max_candidates` must be an integer between `1` and `20`; invalid values raise `ValueError`.
+- The method is read-only and does not create reading queues, sessions, or import plans in persistent storage.
+- Paper Map may call existing read-only planners such as `plan_external_imports_for_paper`.
+
+### MCP Tool
+
+Add:
+
+```python
+workspace_get_paper_map(paper_id: str, max_candidates: int = 5) -> dict
+```
+
+The tool requires an active workspace and follows existing workspace wrapper behavior:
+
+- returns the exact workspace payload on success;
+- converts `KeyError`, `ValueError`, and workspace errors into MCP `ToolError`;
+- does not mutate the active workspace.
+
+### CLI
+
+Add JSON-only command:
+
+```powershell
+papergraph-mcp get-paper-map --workspace C:/Temp/papergraph.sqlite3 --paper-id local:paper
+papergraph-mcp get-paper-map --workspace C:/Temp/papergraph.sqlite3 --paper-id local:paper --max-candidates 3
+```
+
+For consistency with existing commands, also accept the existing global-style invocation:
+
+```powershell
+papergraph-mcp --workspace C:/Temp/papergraph.sqlite3 get-paper-map local:paper
+```
+
+The command prints one JSON payload on success. On failure, it prints one error message to stderr and exits with code `1`.
+
+## Payload Shape
+
+`get_paper_map` returns:
+
+```python
+{
+    "map_schema_version": 1,
+    "paper": {
+        "paper_id": "local:paper-a",
+        "source_type": "local" | "arxiv" | "pdf",
+        "title": "..." | None,
+        "arxiv_id": "..." | None,
+        "result_count": 7,
+        "proof_count": 4,
+        "citation_count": 3,
+    },
+    "summary": {
+        "main_candidate_count": 2,
+        "section_count": 4,
+        "external_risk_count": 1,
+        "unresolved_risk_count": 1,
+        "recommended_start_result_id": "local:paper-a::thm:main" | None,
+        "evidence_status": "usable" | "sparse" | "limited",
+    },
+    "main_result_candidates": [
+        {
+            "result_id": "local:paper-a::thm:main",
+            "display_kind": "theorem",
+            "label": "thm:main" | None,
+            "title": "Theorem 1.1" | None,
+            "statement_preview": "A bounded preview...",
+            "score": 8,
+            "status": "candidate",
+            "reasons": [
+                {
+                    "kind": "label_signal",
+                    "weight": 3,
+                    "evidence": "label contains 'main'",
+                }
+            ],
+            "source_span": {...} | None,
+            "reading_path": {
+                "local_result_count": 2,
+                "proof_count": 2,
+                "external_stop_count": 1,
+                "unresolved_stop_count": 1,
+                "top_down_result_ids": [...],
+                "external_stop_ids": [...],
+                "unresolved_stop_ids": [...],
+            },
+        }
+    ],
+    "structure": {
+        "sections": [
+            {
+                "section_id": "section:1",
+                "title": "Introduction" | None,
+                "level": 1,
+                "position": 1,
+                "source_span": {...} | None,
+                "result_ids": ["local:paper-a::thm:main"],
+            }
+        ],
+        "uncategorized_result_ids": [],
+        "result_order": ["local:paper-a::thm:main"],
+    },
+    "reading_route": [
+        {
+            "position": 1,
+            "target_kind": "result_id" | "proof_id" | "external_stop" | "unresolved_stop",
+            "target_id": "...",
+            "priority": "start" | "required" | "recommended" | "caution",
+            "reason": "selected_main_candidate" | "local_dependency" | "proof_evidence" | "external_risk" | "unresolved_reference",
+            "evidence": {...},
+        }
+    ],
+    "external_risks": {
+        "candidates": [...],
+        "blocked": [...],
+        "summary": {...},
+    },
+    "evidence_quality": {
+        "status": "usable" | "sparse" | "limited",
+        "warnings": [
+            {
+                "kind": "missing_proof" | "no_main_candidate" | "external_dependencies" | "unresolved_references" | "sparse_pdf_text",
+                "message": "...",
+                "evidence": {...},
+            }
+        ],
+        "boundaries": [
+            "Paper Map does not verify proofs.",
+            "Paper Map does not infer hidden mathematical prerequisites.",
+            "Empty dependencies mean no supported extraction evidence, not absence of mathematical dependencies.",
+        ],
+    },
+}
+```
+
+The payload uses existing nested evidence records where possible instead of inventing parallel schemas.
+
+## Main-Result Candidate Heuristics
+
+Paper Map identifies candidates using conservative, auditable signals. It does not claim that the top candidate is the paper's true main theorem.
+
+### Eligible Results
+
+Eligible candidates include theorem-like records whose normalized or displayed kind is one of:
+
+- `theorem`
+- `proposition`
+- `corollary`
+- `lemma`
+- `definition`
+- PDF-detected theorem-like blocks
+
+Definitions may appear as supporting structure but should receive lower main-result weight unless labels or text strongly indicate a central object.
+
+### Signals
+
+Each signal adds a reason entry:
+
+- `label_signal`: label contains `main`, `principal`, `mainthm`, `main-theorem`, or similar exact textual cue.
+- `title_signal`: result title or heading contains `main result`, `main theorem`, `principal theorem`, or `classification`.
+- `introduction_signal`: result appears in an introduction-like section or before the first methods/proof section.
+- `abstract_signal`: result statement text overlaps with extracted abstract text when abstract evidence is available. If no abstract evidence exists, this signal is absent.
+- `early_theorem_signal`: result is among the first theorem/proposition/corollary records.
+- `proof_dependency_signal`: result has a proof path with local dependencies or external stops, indicating it is supported by proof evidence.
+- `citation_risk_signal`: result proof path includes external stops, making it important for reading planning even if not semantically main.
+
+Signals are simple string/source-order heuristics. The score is only an ordering aid and must be exposed with reasons.
+
+### Ordering
+
+Candidates are sorted by:
+
+1. descending score;
+2. source position;
+3. result ID.
+
+Only the first `max_candidates` are included in `main_result_candidates`, but the `structure.result_order` still lists all results.
+
+## Structure Map
+
+Paper Map should produce a structure map even when section extraction is weak.
+
+Rules:
+
+- Preserve source order from stored source spans or existing result order.
+- If section metadata exists, group results under sections.
+- If section metadata does not exist, return `sections: []` and place all results in `uncategorized_result_ids`.
+- Do not synthesize section names from result statements.
+- Include enough source span evidence for an agent to call `workspace_get_source_slice`.
+
+If the current workspace has no section table or explicit section extractor, v0.10 may implement a lightweight read-only section detector from already stored source text. That detector must be bounded, deterministic, and limited to TeX/PDF heading evidence already stored during import.
+
+## Reading Route
+
+Paper Map should recommend one bounded route rather than dumping every possible path.
+
+Route generation:
+
+1. Choose `recommended_start_result_id` as the first main-result candidate, if one exists.
+2. Call existing reading path logic for that result with `recursive=True`.
+3. Convert the path into route items:
+   - selected result as `start`;
+   - selected proof as `required` when available;
+   - local dependencies as `recommended`;
+   - external stops as `caution`;
+   - unresolved stops as `caution`.
+4. Bound the route to a concise, deterministic size. The initial target route should fit a first screen, while detailed dependency expansion remains available through existing reading-path and reading-queue tools.
+
+Paper Map does not create a persistent reading queue. The response may include a `next_tool` hint such as `workspace_create_reading_queue` so an agent can ask the user before mutating reading state.
+
+## External Risks
+
+Paper Map embeds the existing paper-level external import plan:
+
+```python
+external_risks = workspace.plan_external_imports_for_paper(paper_id)
+```
+
+The embedded plan should preserve:
+
+- candidate `review` payloads from v0.9.3;
+- blocked items;
+- already-imported status;
+- warnings;
+- counts.
+
+Paper Map may add a compact risk summary, but it must not discard the underlying plan evidence.
+
+## Evidence Quality
+
+`evidence_quality.status` is computed from visible extraction coverage:
+
+- `usable`: at least one result exists and either proof evidence, source spans, or citation evidence exists.
+- `sparse`: results exist, but proof/citation/source evidence is thin.
+- `limited`: no results exist, or the paper appears to be extraction-poor.
+
+Warnings should be explicit and bounded:
+
+- `no_results`: no theorem-like results were found.
+- `no_main_candidate`: results exist, but no candidate has enough heuristic evidence.
+- `missing_proof`: a candidate lacks proof evidence.
+- `external_dependencies`: candidate path or paper plan has external import candidates.
+- `unresolved_references`: path or import plan has blocked/unresolved items.
+- `sparse_pdf_text`: PDF-origin paper has unusually sparse extracted text or missing spans when such evidence is available.
+
+Every warning includes an evidence object with relevant counts or IDs.
+
+## Data Flow
+
+1. Validate `paper_id` and `max_candidates`.
+2. Load paper metadata from the workspace.
+3. Load all result records with `list_results(paper_id=paper_id, limit=...)` or an internal unbounded equivalent.
+4. Load proof availability for candidate-scoring candidates only, avoiding expensive full proof expansion for every result when possible.
+5. Build main-result candidates from deterministic heuristics.
+6. Build structure map from stored source order and section evidence.
+7. For the first candidate, call existing reading path logic and convert it into a route.
+8. Call `plan_external_imports_for_paper(paper_id)` and embed the result as `external_risks`.
+9. Compute evidence-quality warnings from counts and route/import-plan summaries.
+10. Return the assembled read-only payload.
+
+## Error Handling
+
+- Unknown paper ID raises `KeyError`.
+- Non-integer `max_candidates` raises `ValueError("max_candidates must be an integer")`.
+- Values below `1` or above `20` raise `ValueError("max_candidates must be between 1 and 20")`.
+- Papers with no results return a valid map with empty candidates and `limited` evidence status.
+- Missing proof evidence creates warnings, not failures.
+- External import planner failures caused by corrupt workspace evidence should surface as map warnings when recoverable; validation/programming errors should still fail loudly.
+
+## Determinism
+
+Paper Map must not use timestamps, random IDs, filesystem iteration order, or live network responses.
+
+Stable ordering rules:
+
+- results by source span start, then result ID;
+- sections by source span start, then title, then generated section ID;
+- candidates by score, source order, result ID;
+- reading route by existing reading path order;
+- warnings by fixed severity order, then kind.
+
+## Documentation
+
+README updates should keep the researcher-first style:
+
+- add Paper Map to "What PaperGraph Helps You Do";
+- add `workspace_get_paper_map` to the complete tool reference;
+- add `get-paper-map` to CLI shortcuts;
+- add `v0.10.0` to release highlights;
+- preserve the statement that PaperGraph does not verify proofs, perform semantic theorem matching, or infer hidden prerequisites.
+
+The README should describe Paper Map as a first-load overview, not as a mathematical summary engine.
+
+## Testing
+
+Add focused tests for:
+
+- Paper Map returns schema version, paper summary, candidate list, structure, route, external risks, and evidence quality.
+- Main-result candidate reasons are explicit and deterministic for a fixture with a `\label{thm:main}` or PDF "Main Theorem" text.
+- Candidate ordering is deterministic when two results have different source positions and scores.
+- Papers with no strong main-result signals return results plus a `no_main_candidate` warning rather than inventing a main theorem.
+- Route generation uses existing reading-path evidence and includes external/unresolved stops as `caution`.
+- External risks embed the v0.9.3 review summary from `plan_external_imports_for_paper`.
+- Unknown paper ID and invalid `max_candidates` raise expected errors.
+- MCP wrapper returns the map and converts errors.
+- CLI command prints JSON and reports invalid inputs.
+- README/repository metadata tests include `workspace_get_paper_map`, `get-paper-map`, and `v0.10.0`.
+
+Run before handoff:
+
+```powershell
+uv run pytest -q -p no:cacheprovider
+```
+
+## Release
+
+Release as `v0.10.0`.
+
+The release note should emphasize:
+
+- first-load paper overview;
+- evidence-backed main-result candidates;
+- proof-path and external-risk orientation;
+- no proof verification or semantic matching.
+
+## Open Design Decisions
+
+This spec chooses a conservative v0.10: one paper-level map, JSON output, and deterministic heuristic scoring. Later versions can add human-readable Markdown reports, notation/definition indexes, dependency-role classification, and cross-paper literature maps once this overview layer is stable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.9.3"
+version = "0.10.0"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.9.3"
+PAPERGRAPH_VERSION = "0.10.0"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.9.3"
+    "papergraph-mcp.git@v0.10.0"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -26,7 +26,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.9.3 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.10.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/src/papergraph/paper_map.py
+++ b/src/papergraph/paper_map.py
@@ -1,0 +1,525 @@
+"""Evidence-first paper overview assembly."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from papergraph.identity import normalize_paper_id
+
+if TYPE_CHECKING:
+    from papergraph.workspace import Workspace
+
+
+MAIN_RESULT_KINDS = {
+    "theorem",
+    "proposition",
+    "corollary",
+    "lemma",
+    "definition",
+}
+WARNING_ORDER = {
+    "no_results": 0,
+    "no_main_candidate": 1,
+    "missing_proof": 2,
+    "external_dependencies": 3,
+    "unresolved_references": 4,
+    "sparse_pdf_text": 5,
+}
+COUNT_TABLES = {
+    "proofs",
+    "citation_mentions",
+}
+
+
+def build_paper_map(
+    workspace: Workspace,
+    paper_id: str,
+    max_candidates: int = 5,
+) -> dict[str, Any]:
+    """Build a deterministic overview for one stored paper."""
+
+    max_candidates = _validate_max_candidates(max_candidates)
+    normalized_paper_id = normalize_paper_id(paper_id)
+    paper = workspace.get_paper(normalized_paper_id)
+    results = _list_all_results(workspace, normalized_paper_id)
+    proofs_by_result = {
+        result["result_id"]: workspace.get_result_proof(result["result_id"])
+        for result in results
+    }
+    candidates = _main_result_candidates(
+        workspace,
+        results,
+        proofs_by_result,
+        max_candidates,
+    )
+    recommended_start = candidates[0]["result_id"] if candidates else None
+    reading_route = (
+        _reading_route(workspace, recommended_start) if recommended_start else []
+    )
+    external_risks = workspace.plan_external_imports_for_paper(normalized_paper_id)
+    evidence_quality = _evidence_quality(
+        paper,
+        results,
+        candidates,
+        proofs_by_result,
+        reading_route,
+        external_risks,
+    )
+    structure = _structure(results)
+    route_unresolved_count = sum(
+        1 for item in reading_route if item["target_kind"] == "unresolved_stop"
+    )
+    proof_count = _count_rows(workspace, "proofs", normalized_paper_id)
+    citation_count = _count_rows(workspace, "citation_mentions", normalized_paper_id)
+    return {
+        "map_schema_version": 1,
+        "paper": {
+            "paper_id": paper["paper_id"],
+            "source_type": paper["source_type"],
+            "title": paper.get("title"),
+            "arxiv_id": (
+                paper.get("source_ref")
+                if paper.get("source_type") == "arxiv"
+                else None
+            ),
+            "result_count": len(results),
+            "proof_count": proof_count,
+            "citation_count": citation_count,
+        },
+        "summary": {
+            "main_candidate_count": len(candidates),
+            "section_count": len(structure["sections"]),
+            "external_risk_count": external_risks["summary"][
+                "import_candidate_count"
+            ],
+            "unresolved_risk_count": (
+                external_risks["summary"]["blocked_count"] + route_unresolved_count
+            ),
+            "recommended_start_result_id": recommended_start,
+            "evidence_status": evidence_quality["status"],
+        },
+        "main_result_candidates": candidates,
+        "structure": structure,
+        "reading_route": reading_route,
+        "external_risks": external_risks,
+        "evidence_quality": evidence_quality,
+    }
+
+
+def _validate_max_candidates(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("max_candidates must be an integer")
+    if not 1 <= value <= 20:
+        raise ValueError("max_candidates must be between 1 and 20")
+    return value
+
+
+def _list_all_results(workspace: Workspace, paper_id: str) -> list[dict[str, Any]]:
+    rows = workspace._connection.execute(
+        """
+        SELECT
+            results.result_id, results.paper_id, results.local_id,
+            results.kind, results.raw_kind, results.display_kind,
+            results.normalized_kind, results.label, results.visible_number,
+            results.title, results.statement, results.method,
+            results.confidence, papers.source_type
+        FROM results
+        JOIN papers ON papers.paper_id = results.paper_id
+        LEFT JOIN result_source_spans
+          ON result_source_spans.result_id = results.result_id
+         AND result_source_spans.position = 1
+        LEFT JOIN source_spans
+          ON source_spans.id = result_source_spans.span_id
+        WHERE results.paper_id = ?
+        ORDER BY
+            COALESCE(source_spans.page, 0),
+            COALESCE(source_spans.block_index, 0),
+            COALESCE(source_spans.start_offset, 0),
+            results.result_id
+        """,
+        (paper_id,),
+    ).fetchall()
+    return [
+        {
+            "result_id": row[0],
+            "paper_id": row[1],
+            "local_id": row[2],
+            "kind": row[3],
+            "raw_kind": row[4],
+            "display_kind": row[5],
+            "normalized_kind": row[6],
+            "label": row[7],
+            "visible_number": row[8],
+            "title": row[9],
+            "statement": row[10],
+            "method": row[11],
+            "confidence": row[12],
+            "source_type": row[13],
+            "first_location": workspace._first_result_location(row[0]),
+        }
+        for row in rows
+    ]
+
+
+def _main_result_candidates(
+    workspace: Workspace,
+    results: list[dict[str, Any]],
+    proofs_by_result: dict[str, dict[str, Any]],
+    max_candidates: int,
+) -> list[dict[str, Any]]:
+    candidates = []
+    eligible = [
+        result
+        for result in results
+        if (result.get("normalized_kind") or result.get("display_kind"))
+        in MAIN_RESULT_KINDS
+    ]
+    for index, result in enumerate(eligible):
+        candidate = _candidate_for_result(workspace, result, index, proofs_by_result)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    if not candidates and eligible:
+        path = workspace.get_result_reading_path(eligible[0]["result_id"])
+        candidate = _candidate_payload(
+            eligible[0],
+            [
+                {
+                    "kind": "early_theorem_signal",
+                    "weight": 1,
+                    "evidence": "fallback to the first theorem-like record",
+                }
+            ],
+            path,
+        )
+        candidates.append(candidate)
+
+    candidates.sort(
+        key=lambda candidate: (
+            -candidate["score"],
+            _source_position(candidate["source_span"]),
+            candidate["result_id"],
+        )
+    )
+    return candidates[:max_candidates]
+
+
+def _candidate_for_result(
+    workspace: Workspace,
+    result: dict[str, Any],
+    index: int,
+    proofs_by_result: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    path = workspace.get_result_reading_path(result["result_id"])
+    reasons = _candidate_reasons(result, index, path)
+    if not proofs_by_result[result["result_id"]]["known"]:
+        reasons = [
+            reason
+            for reason in reasons
+            if reason["kind"] != "proof_dependency_signal"
+        ]
+    if not reasons:
+        return None
+    return _candidate_payload(result, reasons, path)
+
+
+def _candidate_payload(
+    result: dict[str, Any],
+    reasons: list[dict[str, Any]],
+    path: dict[str, Any],
+) -> dict[str, Any]:
+    score = sum(reason["weight"] for reason in reasons)
+    return {
+        "result_id": result["result_id"],
+        "display_kind": (
+            result.get("normalized_kind")
+            or result.get("display_kind")
+            or result.get("kind")
+        ),
+        "label": result.get("label"),
+        "title": result.get("title") or result.get("visible_number"),
+        "statement_preview": _statement_preview(result.get("statement")),
+        "score": score,
+        "status": "candidate",
+        "reasons": reasons,
+        "source_span": result.get("first_location"),
+        "reading_path": _reading_path_summary(path),
+    }
+
+
+def _candidate_reasons(
+    result: dict[str, Any],
+    index: int,
+    path: dict[str, Any],
+) -> list[dict[str, Any]]:
+    text = " ".join(
+        str(result.get(key) or "")
+        for key in ("label", "title", "visible_number", "statement")
+    ).lower()
+    reasons = []
+    if any(
+        token in text
+        for token in ("main", "principal", "main theorem", "main result")
+    ):
+        reasons.append(
+            {
+                "kind": "title_signal",
+                "weight": 4,
+                "evidence": "result text contains a main-result cue",
+            }
+        )
+    if result.get("label") and any(
+        token in str(result["label"]).lower()
+        for token in ("main", "principal", "mainthm", "main-theorem")
+    ):
+        reasons.append(
+            {
+                "kind": "label_signal",
+                "weight": 4,
+                "evidence": f"label {result['label']!r} contains a main-result cue",
+            }
+        )
+    if index < 3 and (
+        result.get("normalized_kind") or result.get("display_kind")
+    ) in {"theorem", "proposition", "corollary", "lemma"}:
+        reasons.append(
+            {
+                "kind": "early_theorem_signal",
+                "weight": 2,
+                "evidence": (
+                    "result appears among the first theorem-like records"
+                ),
+            }
+        )
+    if path["top_down"]:
+        reasons.append(
+            {
+                "kind": "proof_dependency_signal",
+                "weight": 1,
+                "evidence": "reading path evidence is available",
+            }
+        )
+    if path["external_stops"]:
+        reasons.append(
+            {
+                "kind": "citation_risk_signal",
+                "weight": 1,
+                "evidence": "reading path includes external stops",
+            }
+        )
+    return reasons
+
+
+def _reading_path_summary(path: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "local_result_count": len(path["top_down"]),
+        "proof_count": len(path["top_down"]),
+        "external_stop_count": len(path["external_stops"]),
+        "unresolved_stop_count": len(path["unresolved_stops"]),
+        "top_down_result_ids": [
+            result["result_id"] for result in path["top_down"]
+        ],
+        "external_stop_ids": [
+            stop["mention_id"] for stop in path["external_stops"]
+        ],
+        "unresolved_stop_ids": [
+            f"{stop['result_id']}:{stop['kind']}"
+            for stop in path["unresolved_stops"]
+        ],
+    }
+
+
+def _reading_route(workspace: Workspace, result_id: str) -> list[dict[str, Any]]:
+    path = workspace.get_result_reading_path(result_id)
+    route = [
+        {
+            "position": 1,
+            "target_kind": "result_id",
+            "target_id": result_id,
+            "priority": "start",
+            "reason": "selected_main_candidate",
+            "evidence": {"source": "paper_map.main_result_candidates"},
+        }
+    ]
+    for result in path["top_down"]:
+        proof = workspace.get_result_proof(result["result_id"]).get("known", {}).get(
+            "proof"
+        )
+        if proof:
+            route.append(
+                {
+                    "position": len(route) + 1,
+                    "target_kind": "proof_id",
+                    "target_id": proof["proof_id"],
+                    "priority": "required"
+                    if result["result_id"] == result_id
+                    else "recommended",
+                    "reason": "proof_evidence",
+                    "evidence": {
+                        "source": "reading_path.top_down",
+                        "result_id": result["result_id"],
+                    },
+                }
+            )
+        if result["result_id"] != result_id:
+            route.append(
+                {
+                    "position": len(route) + 1,
+                    "target_kind": "result_id",
+                    "target_id": result["result_id"],
+                    "priority": "recommended",
+                    "reason": "local_dependency",
+                    "evidence": {"source": "reading_path.top_down"},
+                }
+            )
+    for stop in path["external_stops"]:
+        route.append(
+            {
+                "position": len(route) + 1,
+                "target_kind": "external_stop",
+                "target_id": stop["mention_id"],
+                "priority": "caution",
+                "reason": "external_risk",
+                "evidence": stop,
+            }
+        )
+    for stop in path["unresolved_stops"]:
+        route.append(
+            {
+                "position": len(route) + 1,
+                "target_kind": "unresolved_stop",
+                "target_id": f"{stop['result_id']}:{stop['kind']}",
+                "priority": "caution",
+                "reason": "unresolved_reference",
+                "evidence": {
+                    "source": "reading_path.unresolved_stops",
+                    "result_id": stop["result_id"],
+                    "kind": stop["kind"],
+                    "mention_count": len(stop["mentions"]),
+                },
+            }
+        )
+    return route[:20]
+
+
+def _structure(results: list[dict[str, Any]]) -> dict[str, Any]:
+    ordered = sorted(results, key=lambda result: _source_position(result["first_location"]))
+    return {
+        "sections": [],
+        "uncategorized_result_ids": [
+            result["result_id"] for result in ordered
+        ],
+        "result_order": [result["result_id"] for result in ordered],
+    }
+
+
+def _evidence_quality(
+    paper: dict[str, Any],
+    results: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    proofs_by_result: dict[str, dict[str, Any]],
+    reading_route: list[dict[str, Any]],
+    external_risks: dict[str, Any],
+) -> dict[str, Any]:
+    warnings = []
+    if not results:
+        warnings.append(
+            {
+                "kind": "no_results",
+                "message": "No theorem-like results were found for this paper.",
+                "evidence": {"paper_id": paper["paper_id"]},
+            }
+        )
+    elif not candidates:
+        warnings.append(
+            {
+                "kind": "no_main_candidate",
+                "message": "No main-result candidate had supported heuristic evidence.",
+                "evidence": {"result_count": len(results)},
+            }
+        )
+
+    missing_proofs = [
+        result_id
+        for result_id, proof_payload in proofs_by_result.items()
+        if not proof_payload.get("known")
+    ]
+    if missing_proofs and candidates:
+        warnings.append(
+            {
+                "kind": "missing_proof",
+                "message": "Some theorem-like results have no proof evidence.",
+                "evidence": {"result_ids": missing_proofs[:10]},
+            }
+        )
+    if external_risks["summary"]["import_candidate_count"]:
+        warnings.append(
+            {
+                "kind": "external_dependencies",
+                "message": "External import candidates are visible from stored evidence.",
+                "evidence": {
+                    "import_candidate_count": external_risks["summary"][
+                        "import_candidate_count"
+                    ]
+                },
+            }
+        )
+    if external_risks["summary"]["blocked_count"] or any(
+        item["target_kind"] == "unresolved_stop" for item in reading_route
+    ):
+        warnings.append(
+            {
+                "kind": "unresolved_references",
+                "message": "Unresolved references remain in the paper evidence.",
+                "evidence": {"blocked_count": external_risks["summary"]["blocked_count"]},
+            }
+        )
+
+    if not results:
+        status = "limited"
+    elif any(proof_payload.get("known") for proof_payload in proofs_by_result.values()):
+        status = "usable"
+    else:
+        status = "sparse"
+
+    warnings.sort(key=lambda warning: (WARNING_ORDER[warning["kind"]], warning["kind"]))
+    return {
+        "status": status,
+        "warnings": warnings,
+        "boundaries": [
+            "Paper Map does not verify proofs.",
+            "Paper Map does not infer hidden mathematical prerequisites.",
+            (
+                "Empty dependencies mean no supported extraction evidence, "
+                "not absence of mathematical dependencies."
+            ),
+        ],
+    }
+
+
+def _count_rows(workspace: Workspace, table: str, paper_id: str) -> int:
+    if table not in COUNT_TABLES:
+        raise ValueError(f"Unsupported Paper Map count table: {table}")
+    row = workspace._connection.execute(
+        f"SELECT COUNT(*) FROM {table} WHERE paper_id = ?",
+        (paper_id,),
+    ).fetchone()
+    return int(row[0])
+
+
+def _source_position(location: dict[str, Any] | None) -> tuple[int, int, int, str]:
+    if not location:
+        return (0, 0, 0, "")
+    return (
+        int(location.get("page") or 0),
+        int(location.get("block_index") or 0),
+        int(location.get("start_offset") or 0),
+        str(location.get("span_id") or ""),
+    )
+
+
+def _statement_preview(statement: str | None, limit: int = 160) -> str:
+    compact = " ".join((statement or "").split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3].rstrip() + "..."

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -655,6 +655,23 @@ def workspace_plan_external_imports_for_paper(paper_id: str) -> dict:
 
 
 @mcp.tool()
+@_serialized_workspace_tool
+def workspace_get_paper_map(
+    paper_id: str,
+    max_candidates: int = 5,
+) -> dict:
+    """Return an evidence-first first-load map for one stored paper."""
+
+    try:
+        return require_workspace().get_paper_map(
+            paper_id,
+            max_candidates=max_candidates,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
 def load_paper(path: str) -> dict:
     """Load a local LaTeX paper and build its theorem graph."""
 

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -1097,6 +1097,13 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
     paper_import_plan_parser.add_argument("--workspace", required=True)
     paper_import_plan_parser.add_argument("--paper-id", required=True)
+    paper_map_parser = subparsers.add_parser(
+        "get-paper-map",
+        help="Return an evidence-first first-load map for one stored paper.",
+    )
+    paper_map_parser.add_argument("--workspace", required=True)
+    paper_map_parser.add_argument("--paper-id", required=True)
+    paper_map_parser.add_argument("--max-candidates", type=int, default=5)
 
     args = parser.parse_args(argv)
     if args.command == "doctor":
@@ -1302,6 +1309,16 @@ def main(argv: Sequence[str] | None = None) -> None:
             args.workspace,
             lambda workspace: workspace.plan_external_imports_for_paper(
                 args.paper_id,
+            ),
+        )
+        return
+    if args.command == "get-paper-map":
+        _run_workspace_cli_command(
+            args.command,
+            args.workspace,
+            lambda workspace: workspace.get_paper_map(
+                args.paper_id,
+                max_candidates=args.max_candidates,
             ),
         )
         return

--- a/src/papergraph/workspace.py
+++ b/src/papergraph/workspace.py
@@ -32,6 +32,7 @@ from papergraph.models import (
     WorkspaceImportResult,
 )
 from papergraph.parser import latex_project_to_evidence_document, parse_project
+from papergraph.paper_map import build_paper_map
 from papergraph.pdf import load_pdf_evidence_spans
 from papergraph.project import LoadedProject
 from papergraph.reading import (
@@ -1893,6 +1894,16 @@ class Workspace:
                 "paper_id": normalized_paper_id,
                 "recursive": None,
             }
+        )
+
+    @_synchronized
+    def get_paper_map(self, paper_id: str, max_candidates: int = 5) -> dict:
+        """Return an evidence-first first-load map for one stored paper."""
+
+        return build_paper_map(
+            self,
+            paper_id,
+            max_candidates=max_candidates,
         )
 
     @_synchronized

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.9.3\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.10.0\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(
@@ -74,11 +74,11 @@ def test_doctor_prints_json_without_starting_mcp(
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.9.3",
-            "release_tag": "v0.9.3",
+            "version": "0.10.0",
+            "release_tag": "v0.10.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.9.3"
+                "papergraph-mcp.git@v0.10.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -88,7 +88,7 @@ def test_doctor_prints_json_without_starting_mcp(
 
     server.main(["doctor"])
 
-    assert json.loads(capsys.readouterr().out)["version"] == "0.9.3"
+    assert json.loads(capsys.readouterr().out)["version"] == "0.10.0"
 
 
 def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(

--- a/tests/test_cli_paper_map.py
+++ b/tests/test_cli_paper_map.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+
+import fitz
+import pytest
+
+import papergraph.server as server
+from papergraph.workspace import Workspace
+
+
+def write_paper_map_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def create_paper_map_workspace(tmp_path: Path) -> Path:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_paper_map_pdf(pdf)
+    workspace = Workspace.open(workspace_path)
+    try:
+        workspace.import_pdf(pdf, "local:paper")
+    finally:
+        workspace.close()
+    return workspace_path
+
+
+def read_json(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def test_get_paper_map_cli_prints_json(tmp_path: Path, capsys):
+    workspace_path = create_paper_map_workspace(tmp_path)
+
+    server.main(
+        [
+            "get-paper-map",
+            "--workspace",
+            str(workspace_path),
+            "--paper-id",
+            "local:paper",
+            "--max-candidates",
+            "1",
+        ]
+    )
+
+    payload = read_json(capsys)
+    assert payload["map_schema_version"] == 1
+    assert payload["paper"]["paper_id"] == "local:paper"
+    assert len(payload["main_result_candidates"]) == 1
+
+
+def test_get_paper_map_cli_reports_unknown_paper(tmp_path: Path, capsys):
+    workspace_path = create_paper_map_workspace(tmp_path)
+
+    with pytest.raises(SystemExit) as caught:
+        server.main(
+            [
+                "get-paper-map",
+                "--workspace",
+                str(workspace_path),
+                "--paper-id",
+                "local:missing",
+            ]
+        )
+
+    assert caught.value.code == 1
+    payload = read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["command"] == "get-paper-map"
+    assert "Unknown paper id" in payload["message"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,11 +5,11 @@ def test_environment_diagnostics_reports_version_and_release_source():
     result = environment_diagnostics()
 
     assert result["package_name"] == "papergraph-mcp"
-    assert result["version"] == "0.9.3"
-    assert result["release_tag"] == "v0.9.3"
+    assert result["version"] == "0.10.0"
+    assert result["release_tag"] == "v0.10.0"
     assert (
         result["recommended_source"]
-        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3"
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0"
     )
     assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
     assert isinstance(result["warnings"], list)
@@ -25,6 +25,6 @@ def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
 
     result = environment_diagnostics()
 
-    assert result["version"] == "0.9.3"
+    assert result["version"] == "0.10.0"
     assert result["git"] is None
     assert any("Git context unavailable" in warning for warning in result["warnings"])

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.9.3"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.10.0"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.9.3\n"
+        stdout = "papergraph-mcp 0.10.0\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.9.3"
+    assert result["version"] == "papergraph-mcp 0.10.0"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.9.3"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.10.0"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -350,7 +350,7 @@ def test_readme_exposes_agent_guided_setup():
     assert ".agents/skills/setting-up-papergraph/SKILL.md" in text
 
 
-def test_all_onboarding_source_pins_match_v093():
+def test_all_onboarding_source_pins_match_v0100():
     import re
 
     combined = "\n".join(
@@ -361,4 +361,4 @@ def test_all_onboarding_source_pins_match_v093():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.9.3"}
+    assert set(refs) == {"v0.10.0"}

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,7 +24,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.9.3"
+    assert project["version"] == "0.10.0"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -70,7 +70,7 @@ def test_lockfile_contains_project_package():
     )
 
     assert package["name"] == "papergraph-mcp"
-    assert package["version"] == "0.9.3"
+    assert package["version"] == "0.10.0"
 
 
 def test_validate_arxiv_request_module_stdout_is_json_only():
@@ -102,8 +102,8 @@ def test_runtime_and_issue_template_release_strings_remain_pinned():
         if item.get("id") == "version"
     )
 
-    assert f'PaperGraph/0.9.3 (+{REPOSITORY_URL})' in arxiv_source
-    assert version_field["attributes"]["placeholder"] == "0.9.3"
+    assert f'PaperGraph/0.10.0 (+{REPOSITORY_URL})' in arxiv_source
+    assert version_field["attributes"]["placeholder"] == "0.10.0"
 
 
 def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
@@ -144,7 +144,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.9.3" in build_steps
+    assert "papergraph-mcp 0.10.0" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -252,7 +252,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.9.3"
+        "papergraph-mcp.git@v0.10.0"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):
@@ -263,7 +263,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     )
     assert '"command": "uvx"' in readme
     assert pinned_source in readme
-    assert "PaperGraph v0.9.3" in readme
+    assert "PaperGraph v0.10.0" in readme
 
     for tool_name in (
         "load_paper",
@@ -310,9 +310,11 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
         "workspace_plan_external_imports_for_result",
         "workspace_plan_external_imports_for_queue",
         "workspace_plan_external_imports_for_paper",
+        "workspace_get_paper_map",
     ):
         assert f"`{tool_name}`" in readme
 
+    assert "Paper Map" in readme
     assert "statement_explicit_latex_refs_only" in readme
     assert "not evidence that the theorem has no mathematical dependencies" in readme
     assert "TeX proof environments" in readme
@@ -338,6 +340,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     assert "plan-external-imports-for-result" in readme
     assert "plan-external-imports-for-queue" in readme
     assert "plan-external-imports-for-paper" in readme
+    assert "get-paper-map" in readme
     assert "--workspace" in readme
     assert "`get_environment_diagnostics`" in readme
     assert "`validate_arxiv_request`" in readme
@@ -411,8 +414,8 @@ def test_onboarding_uses_v061_release_pin_and_mentions_id_url_conflicts():
         ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
     ).read_text(encoding="utf-8")
 
-    assert "papergraph-mcp.git@v0.9.3" in skill
-    assert "papergraph-mcp 0.9.3" in skill
+    assert "papergraph-mcp.git@v0.10.0" in skill
+    assert "papergraph-mcp 0.10.0" in skill
     assert "validate_arxiv_request" in skill
     assert "load_arxiv_request" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,11 +169,11 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.9.3",
-            "release_tag": "v0.9.3",
+            "version": "0.10.0",
+            "release_tag": "v0.10.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.9.3"
+                "papergraph-mcp.git@v0.10.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -181,7 +181,7 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         },
     )
 
-    assert server.get_environment_diagnostics()["release_tag"] == "v0.9.3"
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.10.0"
 
 
 def test_validate_arxiv_input_tool_reports_conflict():

--- a/tests/test_workspace_paper_map.py
+++ b/tests/test_workspace_paper_map.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+
+import fitz
+import pytest
+
+from papergraph.workspace import Workspace
+
+
+def write_paper_map_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Introduction",
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2, Lemma 9.9, and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+def import_paper_map_pdf(workspace: Workspace, tmp_path: Path) -> str:
+    pdf = tmp_path / "paper-map.pdf"
+    write_paper_map_pdf(pdf)
+    workspace.import_pdf(pdf, "local:paper")
+    return "local:paper::pdf:theorem:1.1"
+
+
+def test_paper_map_returns_researcher_overview(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        result_id = import_paper_map_pdf(workspace, tmp_path)
+
+        paper_map = workspace.get_paper_map("local:paper")
+
+        assert paper_map["map_schema_version"] == 1
+        assert paper_map["paper"]["paper_id"] == "local:paper"
+        assert paper_map["paper"]["result_count"] == 2
+        assert paper_map["paper"]["proof_count"] == 2
+        assert paper_map["summary"]["recommended_start_result_id"] == result_id
+        assert paper_map["summary"]["main_candidate_count"] >= 1
+        assert paper_map["summary"]["external_risk_count"] == 1
+        assert paper_map["summary"]["unresolved_risk_count"] == 1
+        assert paper_map["summary"]["evidence_status"] == "usable"
+        candidate = paper_map["main_result_candidates"][0]
+        assert candidate["result_id"] == result_id
+        assert candidate["display_kind"] == "theorem"
+        assert candidate["status"] == "candidate"
+        assert candidate["statement_preview"]
+        assert {reason["kind"] for reason in candidate["reasons"]} >= {
+            "title_signal",
+            "early_theorem_signal",
+            "proof_dependency_signal",
+            "citation_risk_signal",
+        }
+        assert candidate["reading_path"]["local_result_count"] == 2
+        assert candidate["reading_path"]["external_stop_count"] == 1
+        assert candidate["reading_path"]["unresolved_stop_count"] == 1
+        assert paper_map["structure"]["result_order"] == [
+            "local:paper::pdf:lemma:1.2",
+            "local:paper::pdf:theorem:1.1",
+        ]
+        assert paper_map["reading_route"][0]["target_id"] == result_id
+        assert paper_map["reading_route"][0]["priority"] == "start"
+        assert any(
+            item["target_kind"] == "external_stop" and item["priority"] == "caution"
+            for item in paper_map["reading_route"]
+        )
+        assert paper_map["external_risks"]["candidates"][0]["review"][
+            "citation_keys"
+        ] == ["12"]
+        assert (
+            "Paper Map does not verify proofs."
+            in paper_map["evidence_quality"]["boundaries"]
+        )
+    finally:
+        workspace.close()
+
+
+def test_paper_map_respects_max_candidates(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_paper_map_pdf(workspace, tmp_path)
+
+        paper_map = workspace.get_paper_map("local:paper", max_candidates=1)
+
+        assert len(paper_map["main_result_candidates"]) == 1
+    finally:
+        workspace.close()
+
+
+def test_paper_map_reports_limited_empty_paper(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        workspace._connection.execute(
+            """
+            INSERT INTO papers (
+                paper_id, source_type, source_ref, source_version, title,
+                authors_json, main_file, imported_at, parser_version
+            ) VALUES (
+                'local:empty', 'pdf', 'empty.pdf', NULL, NULL,
+                '[]', 'empty.pdf', '2026-09-10T00:00:00+00:00', 'test'
+            )
+            """
+        )
+        workspace._connection.commit()
+
+        paper_map = workspace.get_paper_map("local:empty")
+
+        assert paper_map["main_result_candidates"] == []
+        assert paper_map["summary"]["recommended_start_result_id"] is None
+        assert paper_map["summary"]["evidence_status"] == "limited"
+        assert paper_map["evidence_quality"]["warnings"][0]["kind"] == "no_results"
+    finally:
+        workspace.close()
+
+
+def test_paper_map_rejects_invalid_max_candidates(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_paper_map_pdf(workspace, tmp_path)
+
+        with pytest.raises(ValueError, match="max_candidates must be an integer"):
+            workspace.get_paper_map("local:paper", max_candidates=True)
+        with pytest.raises(ValueError, match="max_candidates must be between 1 and 20"):
+            workspace.get_paper_map("local:paper", max_candidates=0)
+        with pytest.raises(ValueError, match="max_candidates must be between 1 and 20"):
+            workspace.get_paper_map("local:paper", max_candidates=21)
+    finally:
+        workspace.close()
+
+
+def test_paper_map_rejects_unknown_paper(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        with pytest.raises(KeyError, match="Unknown paper id"):
+            workspace.get_paper_map("local:missing")
+    finally:
+        workspace.close()

--- a/tests/test_workspace_paper_map_server.py
+++ b/tests/test_workspace_paper_map_server.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import fitz
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+
+import papergraph.server as server
+
+
+def write_paper_map_pdf(path: Path) -> None:
+    document = fitz.open()
+    page = document.new_page()
+    y = 72
+    for line in [
+        "Lemma 1.2. Base estimate.",
+        "Proof. This is direct.",
+        "Theorem 1.1. Main result.",
+        "Proof. By Lemma 1.2 and [12, Theorem 3.5].",
+        "References",
+        "[12] A. Author. Cited paper. arXiv:2401.12345v2.",
+    ]:
+        page.insert_text((72, y), line, fontsize=11)
+        y += 18
+    document.save(path)
+    document.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    server._reset_server_state()
+    yield
+    server._reset_server_state()
+
+
+def load_workspace(tmp_path: Path) -> None:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    pdf = tmp_path / "paper.pdf"
+    write_paper_map_pdf(pdf)
+    server.open_workspace(str(workspace_path))
+    server.workspace_add_pdf_paper(str(pdf), "local:paper")
+
+
+def test_paper_map_mcp_tool_returns_payload(tmp_path: Path):
+    load_workspace(tmp_path)
+
+    paper_map = server.workspace_get_paper_map("local:paper", max_candidates=1)
+
+    assert paper_map["map_schema_version"] == 1
+    assert paper_map["paper"]["paper_id"] == "local:paper"
+    assert len(paper_map["main_result_candidates"]) == 1
+    assert paper_map["external_risks"]["summary"]["import_candidate_count"] == 1
+
+
+def test_paper_map_mcp_tool_reports_missing_workspace():
+    with pytest.raises(ToolError, match="open_workspace"):
+        server.workspace_get_paper_map("local:paper")
+
+
+def test_paper_map_mcp_tool_converts_workspace_errors(tmp_path: Path):
+    server.open_workspace(str(tmp_path / "workspace.sqlite3"))
+
+    with pytest.raises(ToolError, match="Unknown paper id"):
+        server.workspace_get_paper_map("local:missing")

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.9.3"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds Paper Map v0.10.0, an evidence-first first-load overview for a stored paper.

## Highlights

- Add `Workspace.get_paper_map`
- Add MCP tool `workspace_get_paper_map`
- Add CLI command `get-paper-map`
- Surface main-result candidates, reading route, external risks, and evidence-quality warnings
- Update README, onboarding pins, diagnostics, CI smoke version, and package version to `0.10.0`

## Testing

- `uv run pytest -q -p no:cacheprovider --basetemp .pytest-tmp`
- Result: `434 passed, 1 skipped`