### PR TITLE
docs: prepare v0.13 v1 readiness pass

### DIFF
--- a/.agents/skills/setting-up-papergraph/SKILL.md
+++ b/.agents/skills/setting-up-papergraph/SKILL.md
@@ -47,23 +47,23 @@ There are three separate approval boundaries:
 Use this immutable release source everywhere; never substitute a branch, a mutable default, or an unreleased revision:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0
 ```
 
 Never request credentials, upload papers, or place a workspace database inside the Git repository.
 
 ### What changed
 
-Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.11.0`; file presence alone is insufficient:
+Only after actions occur, list the executable version checks, the PaperGraph entry added or confirmed, the validation result, and any backup path. Configuration success requires the pinned command below to exit successfully with version `0.12.0`; file presence alone is insufficient:
 
 ```text
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp --version
 ```
 
 The expected output is:
 
 ```text
-papergraph-mcp 0.11.0
+papergraph-mcp 0.12.0
 ```
 
 Before restart, say “launch command validated”; never say “client has loaded the PaperGraph tools.” Tool loading can be confirmed only after the restarted client discovers the server.

--- a/.agents/skills/setting-up-papergraph/references/client-configuration.md
+++ b/.agents/skills/setting-up-papergraph/references/client-configuration.md
@@ -5,7 +5,7 @@ Use only the matching recipe below. In every recipe, detection and configuration
 The pinned source is always:
 
 ```text
-git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
+git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0
 ```
 
 ## Install `uv` and `uvx`
@@ -34,11 +34,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
 - **Proposed mutation:** show this exact native command:
 
   ```text
-  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp
+  codex mcp add papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both change user-level files outside the repository. If an existing `papergraph` entry differs, show the difference and ask before replacing only that entry. After approval, create the backup first and then run the command.
-- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `codex mcp list`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting a controllable Codex client; otherwise tell the user to restart Codex or reload the IDE window.
 - **Official source:** https://learn.chatgpt.com/docs/extend/mcp
 
@@ -48,11 +48,11 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
 - **Proposed mutation:** show this exact user-scoped native command:
 
   ```text
-  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp
+  claude mcp add --transport stdio --scope user papergraph -- uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp
   ```
 
 - **Approval:** ask before creating the backup or running the command because both mutate user-scoped files. Show any differing existing entry before asking to replace only it. After approval, create the backup first and then run the command.
-- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** run `claude mcp get papergraph`, then validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting Claude Code; after restart, direct the user to `/mcp` to inspect the server connection.
 - **Official source:** https://code.claude.com/docs/en/mcp
 
@@ -69,7 +69,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0",
           "papergraph-mcp"
         ]
       }
@@ -78,7 +78,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
   ```
 
 - **Approval:** show the entry and ask before opening or changing user/workspace configuration. Prefer the MCP configuration UI or command. If editing a file, parse it, preserve other servers, and create a timestamped adjacent backup.
-- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the resulting configuration, confirm only the intended entry changed, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before restarting or reloading VS Code; otherwise give one direct reload-window instruction.
 - **Official source:** https://code.visualstudio.com/docs/agent-customization/mcp-servers
 
@@ -94,7 +94,7 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
         "command": "uvx",
         "args": [
           "--from",
-          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0",
+          "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0",
           "papergraph-mcp"
         ]
       }
@@ -103,6 +103,6 @@ git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0
   ```
 
 - **Approval:** ask before editing any discovered client file. Parse it, preserve unrelated entries, and create a timestamped adjacent backup; if safe editing is unavailable, leave the snippet for the user instead.
-- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
+- **Validation:** parse the result, compare the `papergraph` command and arguments, and validate `uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp --version` and `papergraph-mcp doctor`.
 - **Restart:** ask before any restart; if the client cannot be controlled, tell the user to restart it manually and consult its server-status view after reopening.
 - **Official source:** use the selected client's own MCP documentation for placement; do not substitute an unverified path.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: PaperGraph version
-      placeholder: "0.11.0"
+      placeholder: "0.12.0"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Verify installed CLI
         run: |
           version="$(.smoke-venv/bin/papergraph-mcp --version)"
-          test "$version" = "papergraph-mcp 0.11.0"
+          test "$version" = "papergraph-mcp 0.12.0"

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ PaperGraph helps AI agents turn arXiv papers, local LaTeX projects, and born-dig
 
 ### What PaperGraph Helps You Do
 
-| Start with a Paper Map | Trace proof evidence | Plan the next reading step |
-| --- | --- | --- |
-| Identify main-result candidates, result structure, proof-path evidence, and external reading risks before choosing where to read. | Inspect proof-local references, cited stops, source slices, and dependency diagnostics with explicit evidence. | Build reading queues, resume reading sessions, and review external arXiv import candidates before downloading anything. |
+| Start with a Paper Map | Trace proof evidence | Save reading artifacts | Plan across papers |
+| --- | --- | --- | --- |
+| Identify main-result candidates, result structure, proof-path evidence, and external reading risks before choosing where to read. | Inspect proof-local references, cited stops, source slices, and dependency diagnostics with explicit evidence. | Export deterministic Markdown reports that can live in Git, notes, or handoff sessions. | Given a small explicit paper set, export a cross-paper reading plan with selected-paper citation evidence and remaining risks. |
 
 PaperGraph v0.12.0 adds Cross-Paper Reading Plan: a deterministic Markdown plan for an explicit set of related papers, with a recommended reading sequence, selected-paper citation evidence, external risks, and evidence boundaries outside the MCP window.
 
@@ -33,7 +33,7 @@ PaperGraph v0.12.0 adds Cross-Paper Reading Plan: a deterministic Markdown plan 
 | --- | --- |
 | "Do not invent dependencies." | PaperGraph reports evidence-backed links and explains empty results as extraction limits, not mathematical facts. |
 | "Show me the exact source." | Results, proofs, dependencies, and citations carry source spans that can be sliced back out of the original paper. |
-| "Let me review external papers first." | External references become import plans. The agent should ask before importing the next cited paper. |
+| "Let me review external papers first." | External references become import plans. Cross-paper plans separate selected-paper citation evidence from unresolved outside risks. |
 | "Keep my reading state." | Workspaces store queues, sessions, checkpoints, notes, blocked targets, and open questions locally. |
 
 PaperGraph does not verify proofs, perform semantic theorem matching, or claim that similarly worded results are equivalent.
@@ -92,8 +92,9 @@ flowchart LR
 2. List theorem-like results and choose a target theorem.
 3. Inspect the theorem statement, proof evidence, source slice, and dependency diagnostics.
 4. Generate a reading queue from local proof evidence.
-5. Review external import candidates instead of letting the agent download cited papers automatically.
-6. Save checkpoints and notes so the next reading session starts from known state.
+5. Export a single-paper Reading Report when you want a durable Markdown handoff.
+6. For a few related papers, export a Cross-Paper Reading Plan to see selected-paper citation evidence and remaining risks.
+7. Save checkpoints and notes so the next reading session starts from known state.
 
 ### What PaperGraph Does Not Do
 
@@ -108,9 +109,9 @@ flowchart LR
 
 ### PaperGraph 能帮你做什么
 
-| 先看 Paper Map | 追踪证明证据 | 规划下一步阅读 |
-| --- | --- | --- |
-| 在选择阅读目标前，先看到 main-result candidates、结果结构、proof-path evidence 和 external reading risks。 | 查看 proof-local references、citation stops、source slices 和 dependency diagnostics，并保留证据来源。 | 生成 reading queues、恢复 reading sessions，并在下载外部论文前生成可审阅的导入计划。 |
+| 先看 Paper Map | 追踪证明证据 | 保存阅读产物 | 跨论文规划 |
+| --- | --- | --- | --- |
+| 在选择阅读目标前，先看到 main-result candidates、结果结构、proof-path evidence 和 external reading risks。 | 查看 proof-local references、citation stops、source slices 和 dependency diagnostics，并保留证据来源。 | 导出确定性的 Markdown report，方便放进 Git、笔记或交接会话。 | 对一组显式给定的小规模相关论文，导出跨论文阅读计划、选中论文之间的 citation evidence 和剩余风险。 |
 
 v0.12.0 的重点是 Cross-Paper Reading Plan：对一组显式给定的相关论文导出确定性的 Markdown 阅读计划，包含推荐阅读顺序、选中论文之间的 citation evidence、外部阅读风险和证据边界，不再局限于单篇论文输出。
 
@@ -120,7 +121,7 @@ v0.12.0 的重点是 Cross-Paper Reading Plan：对一组显式给定的相关�
 | --- | --- |
 | 不要猜依赖。 | 只报告有证据的链接；空依赖结果解释为抽取限制，而不是数学事实。 |
 | 我要看到原文位置。 | result、proof、dependency、citation 都尽量保留 source span，可回到原文片段。 |
-| 外部论文先让我审。 | 外部引用先变成 import plan，agent 不应自动下载。 |
+| 外部论文先让我审。 | 外部引用先变成 import plan；跨论文计划会区分选中论文之间的 citation evidence 和仍在外部的 unresolved risks。 |
 | 阅读项目要能继续。 | workspace 在本地保存 queue、session、checkpoint、note、blocked target 和 open question。 |
 
 PaperGraph does not verify proofs，也不做 semantic theorem matching；它不会声称两个措辞相似的结果数学上等价。
@@ -167,8 +168,9 @@ papergraph-mcp doctor
 2. 列出 theorem-like results，选择目标定理。
 3. 查看 theorem statement、proof evidence、source slice 和 dependency diagnostics。
 4. 根据本地 proof evidence 生成 reading queue。
-5. 先审阅 external import candidates，再决定是否导入外部论文。
-6. 保存 checkpoints 和 notes，下次继续读时不必从头开始。
+5. 需要持久交接时，导出单篇 Reading Report。
+6. 面对几篇相关论文时，导出 Cross-Paper Reading Plan，查看选中论文之间的 citation evidence 和剩余风险。
+7. 保存 checkpoints 和 notes，下次继续读时不必从头开始。
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PaperGraph helps AI agents turn arXiv papers, local LaTeX projects, and born-dig
 | --- | --- | --- |
 | Identify main-result candidates, result structure, proof-path evidence, and external reading risks before choosing where to read. | Inspect proof-local references, cited stops, source slices, and dependency diagnostics with explicit evidence. | Build reading queues, resume reading sessions, and review external arXiv import candidates before downloading anything. |
 
-PaperGraph v0.11.0 adds Reading Report Export: a deterministic Markdown report that saves a paper's Paper Map, main-result candidates, recommended reading route, external reading risks, and evidence boundaries outside the MCP window.
+PaperGraph v0.12.0 adds Cross-Paper Reading Plan: a deterministic Markdown plan for an explicit set of related papers, with a recommended reading sequence, selected-paper citation evidence, external risks, and evidence boundaries outside the MCP window.
 
 ### Why Researchers Use It
 
@@ -43,11 +43,11 @@ PaperGraph does not verify proofs, perform semantic theorem matching, or claim t
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then verify the pinned GitHub release without cloning:
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
-The pinned command becomes available after the `v0.11.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
+The pinned command becomes available after the `v0.12.0` GitHub Release and tag are published. Pinning the tag keeps MCP client installations reproducible.
 
 Add PaperGraph to an MCP client that accepts JSON-style stdio configuration:
 
@@ -56,7 +56,7 @@ Add PaperGraph to an MCP client that accepts JSON-style stdio configuration:
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0", "papergraph-mcp"]
     }
   }
 }
@@ -112,7 +112,7 @@ flowchart LR
 | --- | --- | --- |
 | 在选择阅读目标前，先看到 main-result candidates、结果结构、proof-path evidence 和 external reading risks。 | 查看 proof-local references、citation stops、source slices 和 dependency diagnostics，并保留证据来源。 | 生成 reading queues、恢复 reading sessions，并在下载外部论文前生成可审阅的导入计划。 |
 
-v0.11.0 的重点是 Reading Report Export：把一篇论文的 Paper Map、main-result candidates、推荐阅读路线、外部阅读风险和证据边界导出成确定性的 Markdown 报告，不再局限于窗口输出。
+v0.12.0 的重点是 Cross-Paper Reading Plan：对一组显式给定的相关论文导出确定性的 Markdown 阅读计划，包含推荐阅读顺序、选中论文之间的 citation evidence、外部阅读风险和证据边界，不再局限于单篇论文输出。
 
 ### 为什么适合数学论文阅读
 
@@ -130,7 +130,7 @@ PaperGraph does not verify proofs，也不做 semantic theorem matching；它不
 先安装 [uv](https://docs.astral.sh/uv/getting-started/installation/)，然后验证固定版本：
 
 ```powershell
-uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0 papergraph-mcp --version
+uvx --from git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0 papergraph-mcp --version
 papergraph-mcp doctor
 ```
 
@@ -141,7 +141,7 @@ papergraph-mcp doctor
   "mcpServers": {
     "papergraph": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0", "papergraph-mcp"]
+      "args": ["--from", "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0", "papergraph-mcp"]
     }
   }
 }
@@ -180,7 +180,7 @@ papergraph-mcp doctor
 | Workflow | Main tools |
 | --- | --- |
 | Load papers | `open_workspace`, `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_add_pdf_paper`, `workspace_list_papers`, `workspace_get_paper` |
-| Map a paper | `workspace_get_paper_map`, `workspace_export_paper_reading_report` |
+| Map papers | `workspace_get_paper_map`, `workspace_export_paper_reading_report`, `workspace_export_cross_paper_reading_plan` |
 | Inspect results | `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_get_citations`, `workspace_search_theorems` |
 | Read a proof | `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path` |
 | Resume reading | `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary` |
@@ -189,7 +189,7 @@ papergraph-mcp doctor
 
 Original single-paper tools: `get_environment_diagnostics`, `validate_arxiv_request`, `load_arxiv_request`, `validate_arxiv_input`, `load_paper`, `load_arxiv_paper`, `list_theorems`, `get_theorem`, `get_dependencies`, `get_dependency_diagnostics`, and `where_used`.
 
-Complete workspace tool index: `open_workspace`, `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_add_pdf_paper`, `workspace_get_paper_map`, `workspace_export_paper_reading_report`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary`, `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, `workspace_apply_reading_queue_to_session`, `workspace_plan_external_imports_for_result`, `workspace_plan_external_imports_for_queue`, `workspace_plan_external_imports_for_paper`.
+Complete workspace tool index: `open_workspace`, `workspace_add_local_paper`, `workspace_add_arxiv_paper`, `workspace_list_papers`, `workspace_get_paper`, `workspace_search_theorems`, `workspace_get_dependencies`, `workspace_get_dependency_diagnostics`, `workspace_get_citations`, `workspace_add_pdf_paper`, `workspace_get_paper_map`, `workspace_export_paper_reading_report`, `workspace_export_cross_paper_reading_plan`, `workspace_list_results`, `workspace_get_result`, `workspace_get_result_proof`, `workspace_get_proof_dependencies`, `workspace_get_external_result_mentions`, `workspace_get_evidence`, `workspace_export_reading_bundle`, `workspace_export_result_reading_context`, `workspace_get_source_slice`, `workspace_get_result_reading_path`, `workspace_create_reading_session`, `workspace_list_reading_sessions`, `workspace_get_reading_session`, `workspace_record_reading_checkpoint`, `workspace_add_reading_note`, `workspace_export_reading_session_summary`, `workspace_create_reading_queue`, `workspace_list_reading_queues`, `workspace_get_reading_queue`, `workspace_apply_reading_queue_to_session`, `workspace_plan_external_imports_for_result`, `workspace_plan_external_imports_for_queue`, `workspace_plan_external_imports_for_paper`.
 
 </details>
 
@@ -203,6 +203,7 @@ papergraph-mcp validate-arxiv-request "[math/0307200](https://arxiv.org/abs/2609
 papergraph-mcp --workspace .\papergraph.sqlite3 get-paper-map local:paper-a
 papergraph-mcp export-paper-reading-report --workspace .\papergraph.sqlite3 --paper-id local:paper-a
 papergraph-mcp export-paper-reading-report --workspace .\papergraph.sqlite3 --paper-id local:paper-a --output report.md
+papergraph-mcp export-cross-paper-reading-plan --workspace .\papergraph.sqlite3 --paper-id local:paper-a --paper-id arxiv:2401.12345 --output cross-paper-plan.md
 papergraph-mcp --workspace .\papergraph.sqlite3 export-reading-bundle local:paper-a
 papergraph-mcp --workspace .\papergraph.sqlite3 export-result-reading-context local:paper-a::thm:main
 papergraph-mcp --workspace .\papergraph.sqlite3 get-source-slice --result-id local:paper-a::thm:main
@@ -265,6 +266,7 @@ PDF extraction is best for born-digital PDFs; scanned PDFs or OCR-heavy files ma
 <details>
 <summary><strong>Release Highlights</strong></summary>
 
+- v0.12.0 added Cross-Paper Reading Plan, a deterministic Markdown artifact for explicit paper sets with recommended sequence, selected-paper citation evidence, external risks, and evidence boundaries.
 - v0.11.0 added Reading Report Export, a deterministic Markdown artifact with Paper Map context, main-result candidates, reading route, external risks, and evidence boundaries.
 - v0.10.0 added Paper Map, an evidence-first first-load overview with main-result candidates, structure, reading route, and external-risk evidence.
 - v0.9.3 added external import review summaries.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ Restart the MCP client after changing its configuration. The server uses stdio, 
 
 Give a coding agent this request:
 
-> Clone https://github.com/lotchuazzz-crypto/papergraph-mcp and help me set up PaperGraph for my MCP client. Read the repository's onboarding instructions after cloning.
+> I use an MCP-capable agent/client. Clone https://github.com/lotchuazzz-crypto/papergraph-mcp and help me configure PaperGraph for it. After cloning, read .agents/skills/setting-up-papergraph/SKILL.md and follow it.
 
 Compatible agents can follow the repository-local [`setting-up-papergraph`](.agents/skills/setting-up-papergraph/SKILL.md) skill. The agent should show you a reusable PaperGraph prompt, explain why `uv` is needed, and ask before installing software, changing client configuration, or restarting the client.
+
+If you do not use an MCP-capable client yet, PaperGraph can still be run from the CLI with `papergraph-mcp doctor` and the workspace commands below.
 
 If your agent clones into a directory that already exists, ask it to run `git fetch --tags origin` before treating the checkout as current. Existing clones can otherwise remain pinned to an old local `origin/main`.
 
@@ -154,9 +156,11 @@ papergraph-mcp doctor
 
 你可以把这段话发给 coding agent：
 
-> Clone https://github.com/lotchuazzz-crypto/papergraph-mcp and help me set up PaperGraph for my MCP client. Read the repository's onboarding instructions after cloning.
+> 我使用的是支持 MCP 的 agent/client。请克隆 https://github.com/lotchuazzz-crypto/papergraph-mcp，并帮我把 PaperGraph 配置进去。克隆后请先阅读 .agents/skills/setting-up-papergraph/SKILL.md 并按它执行。
 
 支持本仓库 skill 的 agent 会读取 [`setting-up-papergraph`](.agents/skills/setting-up-papergraph/SKILL.md)，展示可复用提示词，解释为什么需要 `uv`，并在安装软件、修改客户端配置或重启客户端前询问你。
+
+如果你暂时没有支持 MCP 的 client，也可以先用 CLI：运行 `papergraph-mcp doctor` 和下方 workspace 命令。
 
 如果目标目录已经存在，请让 agent 先运行 `git fetch --tags origin`，再判断仓库是否是最新。否则已有 clone 可能仍停留在旧的本地 `origin/main`。
 

--- a/docs/superpowers/plans/2026-09-12-cross-paper-reading-plan-v0.12.md
+++ b/docs/superpowers/plans/2026-09-12-cross-paper-reading-plan-v0.12.md
@@ -1,0 +1,510 @@
+# Cross-Paper Reading Plan v0.12 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not use subagents for this implementation.
+
+**Goal:** Build v0.12.0 Cross-Paper Reading Plan so a small explicit set of stored papers can be exported as a deterministic Markdown multi-paper reading plan through Workspace, MCP, and CLI.
+
+**Architecture:** Add a focused `cross_paper_reading_plan.py` formatter over existing Paper Map, Reading Report, citation evidence, and external import planner payloads. Keep `Workspace` as a thin synchronized wrapper, keep `server.py` responsible only for MCP/CLI exposure, and keep file writing in the CLI layer.
+
+**Tech Stack:** Python 3.10+, argparse CLI, FastMCP tools, pytest, existing SQLite-backed `Workspace`, existing Paper Map, Reading Report, citation evidence, and external import planner payloads.
+
+## Global Constraints
+
+- Release version is `0.12.0`.
+- Plan schema version is `1`.
+- Markdown only; no PDF, HTML, LLM-authored summaries, new extractors, schema changes, reading-session mutation, automatic discovery, or network calls.
+- Output must be deterministic: no timestamps, random IDs, or environment-specific paths in Workspace/MCP payloads.
+- `paper_ids` must contain between 2 and 8 distinct paper IDs.
+- Unknown paper IDs raise `KeyError`; invalid `paper_ids` and candidate limits raise `ValueError`.
+- `max_candidates_per_paper` validation must match Paper Map's integer range `1..20`.
+- CLI `--output` must not create parent directories implicitly; it may overwrite existing files.
+- Empty/sparse selected papers must appear in valid Markdown with warnings rather than failing.
+
+---
+
+## File Structure
+
+- Create `src/papergraph/cross_paper_reading_plan.py`: plan model construction, explicit cross-paper evidence extraction, deterministic sequence generation, and Markdown rendering.
+- Modify `src/papergraph/workspace.py`: import the builder and add `Workspace.export_cross_paper_reading_plan`.
+- Modify `src/papergraph/server.py`: add MCP tool, CLI parser, CLI output-writing helper, and command dispatch.
+- Add `tests/test_workspace_cross_paper_reading_plan.py`: workspace payload, validation, sequence, warnings, and Markdown rendering coverage.
+- Add `tests/test_workspace_cross_paper_reading_plan_server.py`: MCP wrapper coverage.
+- Add `tests/test_cli_cross_paper_reading_plan.py`: stdout, `--output`, and invalid-output CLI behavior.
+- Modify repository/version docs and tests: `pyproject.toml`, `src/papergraph/arxiv.py`, `README.md`, and tests expecting `0.11.0`.
+
+### Task 1: Workspace Plan Model and Markdown Renderer
+
+**Files:**
+- Create: `src/papergraph/cross_paper_reading_plan.py`
+- Modify: `src/papergraph/workspace.py`
+- Test: `tests/test_workspace_cross_paper_reading_plan.py`
+
+**Interfaces:**
+- Consumes: `Workspace.get_paper_map(paper_id: str, max_candidates: int = 5) -> dict`
+- Consumes: `Workspace.plan_external_imports_for_paper(paper_id: str) -> dict`
+- Consumes: `Workspace.get_citations(paper_id: str, direction: str = "outgoing", include_unresolved: bool = True) -> list[dict]`
+- Produces: `build_cross_paper_reading_plan(workspace, paper_ids: list[str], focus: str | None = None, max_candidates_per_paper: int = 3) -> dict[str, Any]`
+- Produces: `render_cross_paper_reading_plan_markdown(plan_model: dict[str, Any]) -> str`
+- Produces: `Workspace.export_cross_paper_reading_plan(paper_ids: list[str], focus: str | None = None, max_candidates_per_paper: int = 3) -> dict`
+
+- [ ] **Step 1: Write failing workspace tests**
+
+Create `tests/test_workspace_cross_paper_reading_plan.py` with real workspace fixtures:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from papergraph.project import load_project
+from papergraph.workspace import Workspace
+from tests.test_workspace_external_import_planner import import_import_plan_pdf
+from tests.test_workspace_paper_map import import_paper_map_pdf
+
+
+def import_arxiv_context_paper(workspace: Workspace, tmp_path: Path) -> None:
+    tex = tmp_path / "context.tex"
+    tex.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\begin{document}",
+                r"\begin{theorem}\label{main}",
+                "Context fixed point theorem.",
+                r"\end{theorem}",
+                r"\begin{proof}",
+                "This is direct.",
+                r"\end{proof}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    workspace.import_project(
+        "arxiv:2401.12345",
+        "arxiv",
+        "2401.12345",
+        None,
+        load_project(tex),
+    )
+
+
+def test_cross_paper_reading_plan_exports_markdown_payload(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_import_plan_pdf(workspace, tmp_path)
+        import_arxiv_context_paper(workspace, tmp_path)
+
+        plan = workspace.export_cross_paper_reading_plan(
+            ["local:paper", "arxiv:2401.12345"],
+            focus="main result",
+            max_candidates_per_paper=2,
+        )
+
+        assert plan["plan_schema_version"] == 1
+        assert plan["format"] == "markdown"
+        assert plan["paper_ids"] == ["local:paper", "arxiv:2401.12345"]
+        assert plan["focus"] == "main result"
+        assert plan["summary"]["paper_count"] == 2
+        assert plan["summary"]["recommended_start_paper_id"] == "local:paper"
+        assert plan["summary"]["recommended_start_result_id"]
+        assert plan["summary"]["cross_paper_edge_count"] == 1
+        assert plan["summary"]["evidence_status"] == "usable"
+        assert len(plan["papers"]) == 2
+        assert plan["cross_paper_edges"][0]["source_paper_id"] == "local:paper"
+        assert plan["cross_paper_edges"][0]["target_paper_id"] == "arxiv:2401.12345"
+        assert plan["recommended_sequence"][0]["role"] == "start"
+        assert "selected_main_candidate" in plan["recommended_sequence"][0]["reason"]
+        markdown = plan["markdown"]
+        assert markdown.startswith("# Cross-Paper Reading Plan:")
+        assert "## Paper Set" in markdown
+        assert "## Recommended Reading Sequence" in markdown
+        assert "## Cross-Paper Evidence" in markdown
+        assert "`local:paper` cites selected paper `arxiv:2401.12345`" in markdown
+        assert "## Per-Paper Reading Reports" in markdown
+        assert "export-paper-reading-report" in markdown
+        assert "Citation evidence does not imply logical dependency" in markdown
+    finally:
+        workspace.close()
+```
+
+Add tests for:
+
+```python
+def test_cross_paper_reading_plan_warns_without_edges(tmp_path: Path): ...
+def test_cross_paper_reading_plan_rejects_invalid_inputs(tmp_path: Path): ...
+def test_cross_paper_reading_plan_focus_no_match_warns(tmp_path: Path): ...
+def test_cross_paper_reading_plan_includes_sparse_paper(tmp_path: Path): ...
+```
+
+The invalid-input test must assert duplicate IDs, one ID, nine IDs, unknown paper ID, `max_candidates_per_paper=True`, and `max_candidates_per_paper=0`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_workspace_cross_paper_reading_plan.py -q -p no:cacheprovider
+```
+
+Expected: fails because `Workspace.export_cross_paper_reading_plan` does not exist.
+
+- [ ] **Step 3: Implement the plan builder and renderer**
+
+Create `cross_paper_reading_plan.py` with:
+
+```python
+PLAN_SCHEMA_VERSION = 1
+MAX_PAPER_COUNT = 8
+REQUIRED_BOUNDARIES = [
+    "PaperGraph does not verify proofs.",
+    "PaperGraph does not infer hidden mathematical prerequisites.",
+    "PaperGraph does not perform semantic theorem matching.",
+    "Citation evidence does not imply logical dependency unless supported by reading-path evidence.",
+    (
+        "Empty cross-paper edges mean no supported extraction evidence was found, "
+        "not that no relationship exists."
+    ),
+]
+```
+
+Implement:
+
+```python
+def build_cross_paper_reading_plan(workspace, paper_ids, focus=None, max_candidates_per_paper=3):
+    normalized_ids = _validate_paper_ids(workspace, paper_ids)
+    max_candidates_per_paper = _validate_max_candidates_per_paper(max_candidates_per_paper)
+    normalized_focus = _normalize_focus(focus)
+    paper_maps = [
+        workspace.get_paper_map(paper_id, max_candidates=max_candidates_per_paper)
+        for paper_id in normalized_ids
+    ]
+    papers = _paper_summaries(paper_maps)
+    edges = _cross_paper_edges(workspace, normalized_ids)
+    external_risks = _external_risks(workspace, normalized_ids, edges)
+    sequence, focus_matched = _recommended_sequence(normalized_ids, paper_maps, edges, normalized_focus)
+    warnings = _warnings(paper_maps, edges, external_risks, normalized_focus, focus_matched)
+    summary = _summary(normalized_ids, paper_maps, edges, external_risks, sequence)
+    plan = {...}
+    plan["markdown"] = render_cross_paper_reading_plan_markdown(plan)
+    return plan
+```
+
+Cross-paper edges should be built from `workspace.get_citations(source_id, include_unresolved=True)` rows whose `target_paper_id` is in the selected set. Also inspect each selected paper's `plan_external_imports_for_paper` candidates and already-imported items whose `source.recommended_paper_id` is in the selected set.
+
+Markdown must render the required headings, compact paper summaries, ordered sequence, selected-paper citation edges, per-paper candidates, per-paper report commands, external risks, warnings, boundaries, and next commands.
+
+Modify `workspace.py`:
+
+```python
+from papergraph.cross_paper_reading_plan import build_cross_paper_reading_plan
+
+@_synchronized
+def export_cross_paper_reading_plan(
+    self,
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict:
+    """Export a deterministic Markdown reading plan for selected papers."""
+    return build_cross_paper_reading_plan(
+        self,
+        paper_ids,
+        focus=focus,
+        max_candidates_per_paper=max_candidates_per_paper,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_workspace_cross_paper_reading_plan.py -q -p no:cacheprovider
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/cross_paper_reading_plan.py src/papergraph/workspace.py tests/test_workspace_cross_paper_reading_plan.py
+git commit -m "feat: add cross-paper reading plan model"
+```
+
+### Task 2: MCP Tool Exposure
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Test: `tests/test_workspace_cross_paper_reading_plan_server.py`
+
+**Interfaces:**
+- Consumes: `Workspace.export_cross_paper_reading_plan(...) -> dict`
+- Produces: `workspace_export_cross_paper_reading_plan(paper_ids: list[str], focus: str | None = None, max_candidates_per_paper: int = 3) -> dict`
+
+- [ ] **Step 1: Write failing MCP tests**
+
+Create tests that call:
+
+```python
+plan = server.workspace_export_cross_paper_reading_plan(
+    ["local:paper", "arxiv:2401.12345"],
+    focus="main",
+    max_candidates_per_paper=1,
+)
+assert plan["plan_schema_version"] == 1
+assert plan["format"] == "markdown"
+assert plan["summary"]["paper_count"] == 2
+assert "## Cross-Paper Evidence" in plan["markdown"]
+```
+
+Also assert no active workspace and unknown paper raise `ToolError`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_workspace_cross_paper_reading_plan_server.py -q -p no:cacheprovider
+```
+
+Expected: fails because the MCP wrapper does not exist.
+
+- [ ] **Step 3: Implement MCP wrapper**
+
+Add near `workspace_export_paper_reading_report`:
+
+```python
+@mcp.tool()
+@_serialized_workspace_tool
+def workspace_export_cross_paper_reading_plan(
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict:
+    """Export a deterministic Markdown reading plan for selected papers."""
+    try:
+        return require_workspace().export_cross_paper_reading_plan(
+            paper_ids,
+            focus=focus,
+            max_candidates_per_paper=max_candidates_per_paper,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_workspace_cross_paper_reading_plan_server.py -q -p no:cacheprovider
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_workspace_cross_paper_reading_plan_server.py
+git commit -m "feat: expose cross-paper reading plan MCP tool"
+```
+
+### Task 3: CLI Export Command
+
+**Files:**
+- Modify: `src/papergraph/server.py`
+- Test: `tests/test_cli_cross_paper_reading_plan.py`
+
+**Interfaces:**
+- Consumes: `Workspace.export_cross_paper_reading_plan(...) -> dict`
+- Produces command: `export-cross-paper-reading-plan`
+- Produces stdout behavior: Markdown when `--output` is absent, JSON metadata when `--output` is present.
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Add tests that call:
+
+```python
+server.main([
+    "export-cross-paper-reading-plan",
+    "--workspace", str(workspace_path),
+    "--paper-id", "local:paper",
+    "--paper-id", "arxiv:2401.12345",
+    "--focus", "main",
+])
+```
+
+Assert stdout starts with `# Cross-Paper Reading Plan:` and includes `## Next Commands`.
+
+Add `--output` test asserting:
+
+```python
+payload["status"] == "written"
+payload["command"] == "export-cross-paper-reading-plan"
+payload["paper_ids"] == ["local:paper", "arxiv:2401.12345"]
+payload["format"] == "markdown"
+payload["bytes"] == len(output_path.read_bytes())
+payload["plan_schema_version"] == 1
+```
+
+Add invalid parent path test expecting `SystemExit(1)` and JSON `status == "error"`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_cli_cross_paper_reading_plan.py -q -p no:cacheprovider
+```
+
+Expected: fails because command parser/dispatch is missing.
+
+- [ ] **Step 3: Implement CLI parser, writer, and dispatch**
+
+Add parser:
+
+```python
+cross_paper_plan_parser = subparsers.add_parser(
+    "export-cross-paper-reading-plan",
+    help="Export a deterministic Markdown reading plan for selected papers.",
+)
+cross_paper_plan_parser.add_argument("--workspace", required=True)
+cross_paper_plan_parser.add_argument("--paper-id", action="append", required=True)
+cross_paper_plan_parser.add_argument("--focus")
+cross_paper_plan_parser.add_argument("--max-candidates-per-paper", type=int, default=3)
+cross_paper_plan_parser.add_argument("--output")
+```
+
+Add a helper mirroring `_run_reading_report_cli_command`, with command-specific JSON metadata and JSON error payloads.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_cli_cross_paper_reading_plan.py -q -p no:cacheprovider
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src/papergraph/server.py tests/test_cli_cross_paper_reading_plan.py
+git commit -m "feat: add cross-paper reading plan CLI export"
+```
+
+### Task 4: Documentation and Version Bump
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `src/papergraph/arxiv.py`
+- Modify: `README.md`
+- Modify version-pinned tests under `tests/`
+- Modify any release/install helper files found by `rg "0\\.11\\.0|v0\\.11\\.0"`
+
+**Interfaces:**
+- Produces release version: `0.12.0`
+- Produces documented tool: `workspace_export_cross_paper_reading_plan`
+- Produces documented CLI command: `export-cross-paper-reading-plan`
+
+- [ ] **Step 1: Update repository tests first**
+
+Update repository tests to expect:
+
+```python
+"0.12.0"
+"v0.12.0"
+"workspace_export_cross_paper_reading_plan"
+"export-cross-paper-reading-plan"
+```
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_cli.py tests/test_diagnostics.py tests/test_server.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: fails until docs/version files are updated.
+
+- [ ] **Step 2: Implement docs and version updates**
+
+Update:
+
+- `pyproject.toml` version to `0.12.0`.
+- `src/papergraph/arxiv.py` user agent to `PaperGraph/0.12.0`.
+- README launch pins from `v0.11.0` to `v0.12.0`.
+- README release highlight to say v0.12.0 adds Cross-Paper Reading Plan.
+- README tool table and complete workspace tool index with `workspace_export_cross_paper_reading_plan`.
+- README CLI examples with repeated `--paper-id`.
+- Any test fixtures or install docs found by `rg "0\\.11\\.0|v0\\.11\\.0"`.
+
+- [ ] **Step 3: Run focused docs/version tests**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest tests/test_repository.py tests/test_cli.py tests/test_diagnostics.py tests/test_server.py tests/test_onboarding.py -q -p no:cacheprovider
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add pyproject.toml src/papergraph/arxiv.py README.md tests
+git commit -m "docs: document cross-paper reading plan v0.12"
+```
+
+### Task 5: Full Verification and Branch Handoff
+
+**Files:**
+- No implementation files expected beyond previous tasks.
+
+**Interfaces:**
+- Produces verified branch ready for PR/release workflow.
+
+- [ ] **Step 1: Run full verification**
+
+Run:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -p no:cacheprovider
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Confirm clean status**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --oneline -8
+```
+
+Expected: branch is clean and ahead of origin by the spec/plan/implementation commits.
+
+- [ ] **Step 3: Push branch**
+
+Run:
+
+```powershell
+git push origin design/v0.12-cross-paper-reading-plans
+```
+
+Expected: push succeeds.
+
+- [ ] **Step 4: Prepare PR body**
+
+Prepare a PR body summarizing:
+
+- Cross-Paper Reading Plan Markdown export;
+- Workspace/MCP/CLI entry points;
+- explicit-paper-set scope and evidence boundaries;
+- selected-paper citation edges and external risk aggregation;
+- tests run.
+
+If GitHub CLI is available, create the PR against `main`; otherwise provide the compare URL and PR body.

--- a/docs/superpowers/specs/2026-09-12-cross-paper-reading-plan-v0.12-design.md
+++ b/docs/superpowers/specs/2026-09-12-cross-paper-reading-plan-v0.12-design.md
@@ -1,0 +1,634 @@
+# Cross-Paper Reading Plan v0.12 Design
+
+## Purpose
+
+PaperGraph v0.10 made one loaded paper orientable through Paper Map. v0.11 made that orientation durable through Markdown Reading Report export.
+
+The next gap is the original PaperGraph use case at small literature scale: a researcher has two to five related papers already loaded and wants to understand how to read them together. Window output and single-paper reports are useful, but they do not yet answer:
+
+> Which paper and result should I read first, how do the selected papers cite or block each other, what external risks remain, and which single-paper reports should I open next?
+
+v0.12 adds **Cross-Paper Reading Plan**: a deterministic Markdown export for an explicit set of stored papers. It composes existing Paper Map, Reading Report, citation, and external-import evidence into a small reading plan without adding new extraction or semantic matching.
+
+## Product Goal
+
+Given a small explicit set of loaded paper IDs, PaperGraph should export a researcher-readable Markdown plan that answers:
+
+- what each paper contributes according to stored evidence;
+- which paper/result is the best supported starting point;
+- what reading sequence is recommended across the selected papers;
+- which selected-paper citation edges are visible;
+- which citation/import risks still point outside the selected set;
+- what evidence limits prevent stronger claims.
+
+The plan is not a literature-review generator. It should not invent mathematical summaries, infer theorem equivalence, classify hidden prerequisite relations, or claim that a citation edge is a true logical dependency. It should format and connect evidence PaperGraph already has.
+
+## Users
+
+- A mathematical researcher starting from a few known relevant papers.
+- A research agent that needs to hand off a multi-paper reading state to another chat or session.
+- A local literature-workspace maintainer who wants Markdown artifacts in Git, Obsidian, or project notes.
+
+## Design Principles
+
+- **Explicit paper set first:** v0.12 starts from user-provided paper IDs, not global discovery.
+- **Evidence first:** every cross-paper relation must come from stored citation or reading-route evidence, or be clearly marked as missing.
+- **No semantic theorem matching:** do not decide that two results are equivalent or that one theorem proves another unless existing evidence says so.
+- **No new extraction logic:** consume Paper Map, Reading Report, citations, reading paths, and external import plans.
+- **Markdown first:** export deterministic `.md` content; PDF/HTML can render the same model later.
+- **Deterministic output:** identical workspace state and inputs produce byte-stable Markdown.
+- **Small-set ergonomics:** optimize for two to eight papers, where a human can inspect the whole plan.
+
+## Approaches Considered
+
+### Option 1: Search-First Workspace Discovery
+
+PaperGraph could accept a focus query, search all stored results/citations, select related papers, and emit a plan.
+
+This is powerful but too broad for v0.12. It turns the feature into retrieval and ranking infrastructure, and it risks hiding why papers were selected. It also moves away from the current product direction: helping a reader organize known papers before doing large-scale indexing.
+
+### Option 2: Global Citation-Graph Planner
+
+PaperGraph could build a workspace-wide citation graph and rank papers by graph centrality or citation topology.
+
+This is useful later, but it risks overclaiming that citation structure equals reading dependency. It also needs graph-level UX and filtering decisions that are bigger than one release.
+
+### Option 3: Explicit Cross-Paper Reading Plan
+
+PaperGraph accepts a small explicit set of paper IDs and produces a Markdown reading plan from existing evidence.
+
+This is the v0.12 choice. It is narrow, useful, deterministic, and directly extends v0.10/v0.11. It keeps PaperGraph close to the original design goal: organize a few relevant papers into a logical reading chain with visible evidence boundaries.
+
+## Scope
+
+### In Scope
+
+Add a cross-paper report API:
+
+```python
+def export_cross_paper_reading_plan(
+    self,
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict: ...
+```
+
+Add MCP tool:
+
+```python
+workspace_export_cross_paper_reading_plan(
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict
+```
+
+Add CLI command:
+
+```powershell
+papergraph-mcp --workspace .\papergraph.sqlite3 export-cross-paper-reading-plan --paper-id local:paper-a --paper-id local:paper-b
+papergraph-mcp --workspace .\papergraph.sqlite3 export-cross-paper-reading-plan --paper-id local:paper-a --paper-id local:paper-b --focus "fixed point theorem"
+papergraph-mcp --workspace .\papergraph.sqlite3 export-cross-paper-reading-plan --paper-id local:paper-a --paper-id local:paper-b --output reading-plan.md
+```
+
+Generate a structured payload containing:
+
+- plan schema version;
+- format;
+- input paper IDs;
+- optional focus string;
+- per-paper Paper Map summaries;
+- per-paper Reading Report references and commands;
+- recommended cross-paper reading sequence;
+- explicit selected-paper citation edges;
+- unresolved or external citation risks;
+- evidence-quality warnings;
+- generated Markdown text.
+
+Update README/tool tables and release pins for `v0.12.0`.
+
+### Out of Scope
+
+- Automatic discovery of relevant papers.
+- Automatic external import.
+- Network calls.
+- PDF export.
+- HTML export.
+- New citation extraction, theorem extraction, or notation extraction.
+- Semantic theorem matching.
+- LLM-authored mathematical summaries.
+- Persistent database schema changes.
+- Workspace-wide graph centrality or ranking.
+- Mutation of reading sessions or reading queues.
+
+## Public API
+
+### Workspace API
+
+Add to `Workspace`:
+
+```python
+def export_cross_paper_reading_plan(
+    self,
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict:
+    ...
+```
+
+Validation rules:
+
+- `paper_ids` must contain between 2 and 8 distinct IDs.
+- Duplicate paper IDs raise `ValueError`.
+- Unknown paper IDs raise `KeyError`.
+- `max_candidates_per_paper` must be an integer between `1` and `20`, matching Paper Map validation.
+- `focus` may be `None` or a non-empty string after trimming. Empty strings are treated as `None`.
+- The method is read-only.
+- The method does not write files. File writing belongs to the CLI layer.
+
+The returned payload:
+
+```python
+{
+    "plan_schema_version": 1,
+    "format": "markdown",
+    "paper_ids": ["local:paper-a", "local:paper-b"],
+    "focus": "fixed point theorem" | None,
+    "summary": {
+        "paper_count": 2,
+        "recommended_start_paper_id": "local:paper-a" | None,
+        "recommended_start_result_id": "local:paper-a::pdf:theorem:1.1" | None,
+        "main_candidate_count": 4,
+        "cross_paper_edge_count": 1,
+        "external_risk_count": 2,
+        "unresolved_risk_count": 1,
+        "evidence_status": "usable" | "sparse" | "limited",
+    },
+    "papers": [
+        {
+            "paper_id": "local:paper-a",
+            "title": "..." | None,
+            "paper_map_summary": {...},
+            "main_result_candidates": [...],
+            "reading_route_preview": [...],
+            "single_paper_report_command": "papergraph-mcp ...",
+            "warnings": [...],
+        }
+    ],
+    "cross_paper_edges": [
+        {
+            "source_paper_id": "local:paper-a",
+            "target_paper_id": "local:paper-b",
+            "kind": "citation_evidence",
+            "citation_key": "12" | None,
+            "source_result_id": "..." | None,
+            "source_proof_id": "..." | None,
+            "mention_id": "...",
+            "raw_text": "...",
+            "evidence": {...},
+        }
+    ],
+    "recommended_sequence": [
+        {
+            "position": 1,
+            "paper_id": "local:paper-a",
+            "result_id": "local:paper-a::pdf:theorem:1.1" | None,
+            "role": "start" | "context" | "continue" | "review",
+            "reason": "selected_main_candidate" | "selected_paper_citation" | "focus_match" | "input_order",
+            "evidence": {...},
+        }
+    ],
+    "external_risks": [...],
+    "warnings": [...],
+    "evidence_boundaries": [...],
+    "markdown": "# Cross-Paper Reading Plan: ...\n...",
+}
+```
+
+### MCP Tool
+
+Add:
+
+```python
+workspace_export_cross_paper_reading_plan(
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict
+```
+
+The tool returns the full payload, including Markdown text. It requires an active workspace and converts workspace validation errors into `ToolError`, matching existing workspace tool patterns.
+
+### CLI
+
+Add:
+
+```powershell
+papergraph-mcp --workspace C:/Temp/papergraph.sqlite3 export-cross-paper-reading-plan --paper-id local:a --paper-id local:b
+papergraph-mcp --workspace C:/Temp/papergraph.sqlite3 export-cross-paper-reading-plan --paper-id local:a --paper-id local:b --focus "fixed point"
+papergraph-mcp --workspace C:/Temp/papergraph.sqlite3 export-cross-paper-reading-plan --paper-id local:a --paper-id local:b --max-candidates-per-paper 2
+papergraph-mcp --workspace C:/Temp/papergraph.sqlite3 export-cross-paper-reading-plan --paper-id local:a --paper-id local:b --output C:/Temp/plan.md
+```
+
+CLI behavior:
+
+- `--paper-id` is repeatable. Do not accept comma-separated IDs in v0.12.
+- Without `--output`, print Markdown to stdout.
+- With `--output`, write Markdown to that path and print JSON metadata to stdout:
+
+```json
+{
+  "status": "written",
+  "command": "export-cross-paper-reading-plan",
+  "paper_ids": ["local:a", "local:b"],
+  "format": "markdown",
+  "output": "C:/Temp/plan.md",
+  "bytes": 12345,
+  "plan_schema_version": 1
+}
+```
+
+- On error, print one JSON error payload to stdout and exit with code `1`, following Reading Report Export conventions.
+- `--output` must not create parent directories implicitly.
+- `--output` may overwrite an existing file.
+
+## Evidence Sources
+
+The v0.12 implementation should consume only existing evidence:
+
+- `Workspace.get_paper_map(paper_id, max_candidates=max_candidates_per_paper)`
+- `Workspace.export_paper_reading_report(paper_id, max_candidates=max_candidates_per_paper)` for report model consistency when needed
+- `Workspace.plan_external_imports_for_paper(paper_id)`
+- stored citation mentions and external-result mentions
+- reading-route evidence already embedded in Paper Map
+- optional existing search helpers for focus scoring, if they are already local and deterministic
+
+If focus search would require new extraction or new ranking infrastructure, v0.12 should use focus only as a display label and a conservative text filter over already-returned candidate titles/statements/reasons.
+
+## Cross-Paper Edge Rules
+
+Cross-paper edges are allowed only when stored evidence explicitly connects two selected papers.
+
+Valid evidence:
+
+- a citation mention whose resolved or stored target paper ID is one of the selected paper IDs;
+- an external import candidate or already-imported item whose stored paper ID matches one of the selected paper IDs;
+- a reading-route external stop whose evidence can be traced to a selected paper through stored citation/import evidence.
+
+Invalid evidence:
+
+- similar titles;
+- similar theorem statements;
+- shared arXiv IDs found only in raw text without stored resolution;
+- bibliography string similarity;
+- user-provided paper order alone.
+
+When evidence is insufficient, the plan may say:
+
+```markdown
+No selected-paper citation edge was extracted between `local:a` and `local:b`.
+```
+
+It must not say that the papers are unrelated.
+
+Edge wording should use "citation evidence connects" or "selected-paper citation edge", not "depends on", unless an existing reading-path record explicitly supports dependency language.
+
+## Recommended Sequence
+
+The sequence is a reading recommendation, not a dependency proof.
+
+Generation rules:
+
+1. Build a Paper Map for every selected paper.
+2. Choose the recommended start paper/result:
+   - If `focus` is supplied, prefer the highest-scoring main candidate whose title, label, statement preview, or evidence reason contains the focus tokens.
+   - Otherwise prefer the highest-scoring main candidate across Paper Maps.
+   - Tie-break by input paper order, then source order, then result ID.
+3. Add the start item with role `start`.
+4. Add selected papers cited by the start paper before or near the citing paper's route with role `context`.
+5. Add remaining selected papers in input order with role `continue`.
+6. Add papers with no candidates but usable metadata with role `review`.
+7. Surface external and unresolved risks after the sequence, not as normal sequence items.
+
+Every sequence item must include evidence:
+
+- `paper_map.main_result_candidates` for selected starts;
+- `cross_paper_edges` for selected-paper citation context;
+- `paper_ids.input_order` for fallback ordering;
+- warning evidence for sparse or limited papers.
+
+## Evidence Quality
+
+Plan-level evidence status:
+
+- `usable`: at least one selected paper has usable Paper Map evidence and every selected paper exists.
+- `sparse`: selected papers exist, but most maps are sparse or lack proof/citation evidence.
+- `limited`: no selected paper has main-result candidates or usable route evidence.
+
+Warnings should use stable kinds:
+
+- `no_cross_paper_edges`: selected papers have no extracted citation edges between them.
+- `sparse_paper`: one or more selected papers has sparse evidence.
+- `limited_paper`: one or more selected papers has limited evidence.
+- `external_dependencies`: external import candidates remain outside the selected set.
+- `unresolved_references`: unresolved references remain.
+- `focus_no_match`: focus text did not match candidate titles, previews, labels, or reasons.
+- `edge_resolution_limited`: citation evidence exists but cannot be resolved to selected paper IDs.
+
+Warnings should include evidence counts and IDs. Sparse evidence is a warning, not a failure.
+
+## Markdown Content
+
+The Markdown report should use stable headings:
+
+```markdown
+# Cross-Paper Reading Plan: <focus or N papers>
+
+## Scope
+
+## Paper Set
+
+## Recommended Reading Sequence
+
+## Cross-Paper Evidence
+
+## Per-Paper Main Candidates
+
+## Per-Paper Reading Reports
+
+## External Reading Risks
+
+## Evidence Quality
+
+## Evidence Boundaries
+
+## Next Commands
+```
+
+### Scope
+
+Include:
+
+- selected paper IDs;
+- optional focus;
+- format and schema version;
+- selected paper count.
+
+Do not include timestamps.
+
+### Paper Set
+
+For each paper:
+
+- paper ID;
+- title when known;
+- result/proof/citation counts from Paper Map;
+- evidence status;
+- recommended start result when available.
+
+### Recommended Reading Sequence
+
+Render sequence items as an ordered list:
+
+```markdown
+1. `local:paper-a` / `local:paper-a::pdf:theorem:1.1` start - selected_main_candidate
+2. `local:paper-b` context - selected_paper_citation from `local:paper-a`
+3. `local:paper-c` continue - input_order
+```
+
+Every item should include concise evidence in prose or compact JSON.
+
+### Cross-Paper Evidence
+
+Render selected-paper citation edges:
+
+```markdown
+- `local:paper-a` cites selected paper `local:paper-b`.
+  - Mention: `...`
+  - Citation key: `12`
+  - Raw text: ...
+```
+
+If no selected-paper edges exist, state that no edge was extracted. Do not infer absence of relation.
+
+### Per-Paper Main Candidates
+
+For each paper, include the top candidates from its Paper Map:
+
+- result ID;
+- kind;
+- title or visible number;
+- score;
+- reason records.
+
+This section should be compact. Full details belong in the single-paper reports.
+
+### Per-Paper Reading Reports
+
+Include commands to export each single-paper report:
+
+```powershell
+papergraph-mcp --workspace <WORKSPACE> export-paper-reading-report --paper-id local:paper-a --output local-paper-a-reading-report.md
+```
+
+The API cannot know the workspace path, so `<WORKSPACE>` remains a placeholder. CLI may substitute the provided workspace path in the generated Markdown only if this does not break determinism for API calls. The simpler v0.12 rule is to always use `<WORKSPACE>`.
+
+### External Reading Risks
+
+Aggregate external risks from all selected papers:
+
+- import candidates outside the selected set;
+- already-imported candidates not in the selected set;
+- blocked/unresolved items;
+- citation keys and raw snippets when available.
+
+Selected-paper citation edges should be removed from external risk counts where possible, because they are handled in `Cross-Paper Evidence`.
+
+### Evidence Quality
+
+Render plan-level warnings first, then per-paper warnings.
+
+Warnings should stay factual:
+
+```markdown
+- `no_cross_paper_edges`: no stored citation edge was extracted between the selected papers.
+```
+
+### Evidence Boundaries
+
+Always include:
+
+- PaperGraph does not verify proofs.
+- PaperGraph does not infer hidden mathematical prerequisites.
+- PaperGraph does not perform semantic theorem matching.
+- Citation evidence does not imply logical dependency unless supported by reading-path evidence.
+- Empty cross-paper edges mean no supported extraction evidence was found, not that no relationship exists.
+
+### Next Commands
+
+Include copyable commands:
+
+```powershell
+papergraph-mcp --workspace <WORKSPACE> get-paper-map local:paper-a
+papergraph-mcp --workspace <WORKSPACE> export-paper-reading-report --paper-id local:paper-a
+papergraph-mcp --workspace <WORKSPACE> plan-external-imports-for-paper local:paper-a
+```
+
+For every selected paper, include one report command. For brevity, include `get-paper-map` and `plan-external-imports-for-paper` commands for the recommended start paper first.
+
+## Architecture
+
+Create:
+
+```text
+src/papergraph/cross_paper_reading_plan.py
+```
+
+Responsibilities:
+
+- `build_cross_paper_reading_plan(workspace, paper_ids, focus=None, max_candidates_per_paper=3) -> dict`
+- `render_cross_paper_reading_plan_markdown(plan_model: dict) -> str`
+- input validation helpers;
+- cross-paper edge extraction helpers;
+- deterministic sequence generation helpers;
+- small Markdown escaping/formatting helpers.
+
+`Workspace.export_cross_paper_reading_plan` should be a thin wrapper around this module.
+
+`server.py` should expose MCP and CLI wrappers only. It should not contain plan rendering logic.
+
+No database migration is needed for v0.12.
+
+## Data Flow
+
+1. Normalize and validate input paper IDs.
+2. Load each paper through existing workspace methods.
+3. Build `get_paper_map` for each paper with `max_candidates_per_paper`.
+4. Collect selected-paper citation edges from stored citation/import evidence.
+5. Aggregate external and unresolved risks from Paper Map and import plans.
+6. Score candidate start results using Paper Map scores and optional focus token matches.
+7. Build the recommended sequence with deterministic tie-breaks.
+8. Compute plan-level evidence status and warnings.
+9. Render deterministic Markdown.
+10. Return the payload from Workspace/MCP or write Markdown through CLI `--output`.
+
+## Focus Handling
+
+`focus` is optional and conservative.
+
+Normalize by:
+
+- trimming whitespace;
+- lowercasing for matching;
+- splitting on whitespace;
+- ignoring tokens shorter than three characters.
+
+Use focus only to prefer already-extracted candidates whose:
+
+- label,
+- title,
+- statement preview,
+- or reason evidence
+
+contains at least one focus token.
+
+If no candidates match, keep the normal start selection and add `focus_no_match` warning. Do not call an LLM or infer mathematical relevance.
+
+## Determinism
+
+The plan must not use:
+
+- timestamps;
+- random IDs;
+- filesystem iteration order;
+- live network responses;
+- environment-specific absolute paths.
+
+Stable ordering rules:
+
+- papers by input order;
+- candidate starts by focus match, descending score, input paper order, source position, result ID;
+- cross-paper edges by source paper input order, target paper input order, mention ID;
+- warnings by fixed severity order, then kind, then paper ID;
+- external risks by source paper input order, then existing planner order.
+
+## Error Handling
+
+- Fewer than two paper IDs raise `ValueError("paper_ids must contain between 2 and 8 distinct IDs")`.
+- More than eight paper IDs raise the same `ValueError`.
+- Duplicate paper IDs raise `ValueError("paper_ids must be distinct")`.
+- Unknown paper ID raises `KeyError`.
+- Invalid `max_candidates_per_paper` raises the same validation errors as Paper Map, with the parameter name adjusted where appropriate.
+- Papers with no results still appear in the plan with warnings.
+- Missing cross-paper edges produce a warning, not a failure.
+- CLI output errors:
+  - missing parent directory: JSON error, exit `1`;
+  - target path is a directory: JSON error, exit `1`;
+  - write permission failure: JSON error, exit `1`.
+
+## Testing
+
+Add focused tests for:
+
+- Workspace payload includes schema version, format, paper IDs, summary, papers, sequence, warnings, and Markdown.
+- Duplicate, too few, too many, unknown, and invalid candidate-limit inputs fail predictably.
+- Per-paper Paper Map summaries are embedded for all selected papers.
+- Recommended start is deterministic without focus.
+- Focus changes start selection only when an extracted candidate text/reason matches focus tokens.
+- `focus_no_match` warning appears when focus matches nothing.
+- Cross-paper citation edge appears only when stored evidence explicitly connects selected papers.
+- No cross-paper edge warning appears when selected papers have no extracted edge.
+- External risks outside the selected set are aggregated.
+- Sparse and empty papers are included with warnings.
+- Markdown includes all required headings and evidence boundaries.
+- MCP wrapper returns the payload and converts errors.
+- CLI without `--output` prints Markdown.
+- CLI with `--output` writes Markdown and prints JSON metadata.
+- CLI reports invalid output paths.
+- README/repository tests include `workspace_export_cross_paper_reading_plan`, `export-cross-paper-reading-plan`, and `v0.12.0`.
+
+Run before handoff:
+
+```powershell
+uv run pytest -q -p no:cacheprovider
+```
+
+## Documentation
+
+README updates should:
+
+- describe Cross-Paper Reading Plan as the way to organize a small explicit set of related papers;
+- add `workspace_export_cross_paper_reading_plan` to the complete tool reference;
+- add CLI examples with repeated `--paper-id`;
+- update release highlights for `v0.12.0`;
+- preserve evidence-boundary language.
+
+The README should describe this feature as a reading plan, not as a literature review or automatic survey engine.
+
+## Release
+
+Release as `v0.12.0`.
+
+Release notes should emphasize:
+
+- Markdown Cross-Paper Reading Plan export;
+- explicit multi-paper input;
+- evidence-backed recommended sequence;
+- selected-paper citation edges;
+- external and unresolved risk aggregation;
+- no proof verification, semantic theorem matching, or automatic discovery.
+
+## v1.0 Implications
+
+Cross-Paper Reading Plan closes one of the largest remaining gaps before v1.0: PaperGraph will support both single-paper orientation and small-set literature reading artifacts.
+
+After v0.12, the remaining v1.0 blockers should be small and stabilizing:
+
+1. Normalize evidence-status vocabulary across Paper Map, Reading Report, and Cross-Paper Reading Plan.
+2. Freeze the CLI/MCP contract for the core reading workflow.
+3. Improve installation and first-workspace walkthrough documentation.
+4. Run one release-candidate pass over error messages, examples, and Markdown output quality.
+
+Notation, symbol indexing, global paper discovery, and PDF rendering should remain post-v1.0 unless a later design keeps them strictly evidence-scoped and clearly useful for the core reading workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "papergraph-mcp"
-version = "0.11.0"
+version = "0.12.0"
 description = "Turn mathematical LaTeX papers into theorem dependency graphs for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_onboarding.py
+++ b/scripts/check_onboarding.py
@@ -9,10 +9,10 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 
-PAPERGRAPH_VERSION = "0.11.0"
+PAPERGRAPH_VERSION = "0.12.0"
 PAPERGRAPH_SOURCE = (
     "git+https://github.com/lotchuazzz-crypto/"
-    "papergraph-mcp.git@v0.11.0"
+    "papergraph-mcp.git@v0.12.0"
 )
 LAUNCH_COMMAND = [
     "uvx",

--- a/src/papergraph/arxiv.py
+++ b/src/papergraph/arxiv.py
@@ -26,7 +26,7 @@ from papergraph.loader import _is_commented
 
 ARXIV_SOURCE_BASE = "https://export.arxiv.org/e-print"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-_USER_AGENT = "PaperGraph/0.11.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
+_USER_AGENT = "PaperGraph/0.12.0 (+https://github.com/lotchuazzz-crypto/papergraph-mcp)"
 _MODERN_ID_RE = re.compile(r"\d{4}\.\d{4,5}(?:v[1-9]\d*)?")
 _LEGACY_ID_RE = re.compile(
     r"[A-Za-z][A-Za-z0-9.-]*/\d{7}(?:v[1-9]\d*)?"

--- a/src/papergraph/cross_paper_reading_plan.py
+++ b/src/papergraph/cross_paper_reading_plan.py
@@ -1,0 +1,738 @@
+"""Deterministic Markdown cross-paper reading plan assembly."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from papergraph.identity import normalize_paper_id
+
+if TYPE_CHECKING:
+    from papergraph.workspace import Workspace
+
+
+PLAN_SCHEMA_VERSION = 1
+MAX_PAPER_COUNT = 8
+REQUIRED_BOUNDARIES = [
+    "PaperGraph does not verify proofs.",
+    "PaperGraph does not infer hidden mathematical prerequisites.",
+    "PaperGraph does not perform semantic theorem matching.",
+    (
+        "Citation evidence does not imply logical dependency unless supported "
+        "by reading-path evidence."
+    ),
+    (
+        "Empty cross-paper edges mean no supported extraction evidence was found, "
+        "not that no relationship exists."
+    ),
+]
+WARNING_ORDER = {
+    "focus_no_match": 0,
+    "no_cross_paper_edges": 1,
+    "limited_paper": 2,
+    "sparse_paper": 3,
+    "external_dependencies": 4,
+    "unresolved_references": 5,
+    "edge_resolution_limited": 6,
+}
+
+
+def build_cross_paper_reading_plan(
+    workspace: Workspace,
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict[str, Any]:
+    """Build a deterministic Markdown reading plan for selected papers."""
+
+    normalized_ids = _validate_paper_ids(workspace, paper_ids)
+    max_candidates_per_paper = _validate_max_candidates_per_paper(
+        max_candidates_per_paper
+    )
+    normalized_focus = _normalize_focus(focus)
+    paper_maps = [
+        workspace.get_paper_map(
+            paper_id,
+            max_candidates=max_candidates_per_paper,
+        )
+        for paper_id in normalized_ids
+    ]
+    papers = _paper_summaries(paper_maps)
+    cross_edges = _cross_paper_edges(workspace, normalized_ids)
+    external_risks = _external_risks(workspace, normalized_ids, cross_edges)
+    recommended_sequence, focus_matched = _recommended_sequence(
+        normalized_ids,
+        paper_maps,
+        cross_edges,
+        normalized_focus,
+    )
+    warnings = _warnings(
+        paper_maps,
+        cross_edges,
+        external_risks,
+        normalized_focus,
+        focus_matched,
+    )
+    summary = _summary(
+        normalized_ids,
+        paper_maps,
+        cross_edges,
+        external_risks,
+        recommended_sequence,
+    )
+    plan: dict[str, Any] = {
+        "plan_schema_version": PLAN_SCHEMA_VERSION,
+        "format": "markdown",
+        "paper_ids": normalized_ids,
+        "focus": normalized_focus,
+        "summary": summary,
+        "papers": papers,
+        "cross_paper_edges": cross_edges,
+        "recommended_sequence": recommended_sequence,
+        "external_risks": external_risks,
+        "warnings": warnings,
+        "evidence_boundaries": REQUIRED_BOUNDARIES,
+    }
+    plan["markdown"] = render_cross_paper_reading_plan_markdown(plan)
+    return plan
+
+
+def render_cross_paper_reading_plan_markdown(
+    plan_model: dict[str, Any],
+) -> str:
+    """Render a cross-paper reading plan payload as Markdown."""
+
+    focus = plan_model.get("focus")
+    title = focus or f"{len(plan_model['paper_ids'])} papers"
+    summary = plan_model["summary"]
+    lines = [
+        f"# Cross-Paper Reading Plan: {_text(title)}",
+        "",
+        "## Scope",
+        "",
+        f"- Paper count: {summary['paper_count']}",
+        f"- Paper IDs: {', '.join(f'`{paper_id}`' for paper_id in plan_model['paper_ids'])}",
+        f"- Focus: {_code_or_none(focus)}",
+        f"- Plan format: `{plan_model['format']}`",
+        f"- Plan schema version: {plan_model['plan_schema_version']}",
+        "",
+        "## Paper Set",
+        "",
+    ]
+    lines.extend(_render_paper_set(plan_model["papers"]))
+    lines.extend(["", "## Recommended Reading Sequence", ""])
+    lines.extend(_render_sequence(plan_model["recommended_sequence"]))
+    lines.extend(["", "## Cross-Paper Evidence", ""])
+    lines.extend(_render_edges(plan_model["cross_paper_edges"]))
+    lines.extend(["", "## Per-Paper Main Candidates", ""])
+    lines.extend(_render_candidates(plan_model["papers"]))
+    lines.extend(["", "## Per-Paper Reading Reports", ""])
+    lines.extend(_render_report_commands(plan_model["papers"]))
+    lines.extend(["", "## External Reading Risks", ""])
+    lines.extend(_render_external_risks(plan_model["external_risks"]))
+    lines.extend(["", "## Evidence Quality", ""])
+    lines.extend(_render_warnings(plan_model["warnings"], plan_model["papers"]))
+    lines.extend(["", "## Evidence Boundaries", ""])
+    lines.extend(f"- {boundary}" for boundary in plan_model["evidence_boundaries"])
+    lines.extend(["", "## Next Commands", "", "```powershell"])
+    start_paper = summary["recommended_start_paper_id"] or plan_model["paper_ids"][0]
+    lines.extend(
+        [
+            f"papergraph-mcp --workspace <WORKSPACE> get-paper-map {start_paper}",
+            (
+                "papergraph-mcp --workspace <WORKSPACE> "
+                f"plan-external-imports-for-paper {start_paper}"
+            ),
+        ]
+    )
+    for paper in plan_model["papers"]:
+        lines.append(paper["single_paper_report_command"])
+    lines.append("```")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _validate_paper_ids(workspace: Workspace, paper_ids: list[str]) -> list[str]:
+    if not isinstance(paper_ids, list):
+        raise ValueError("paper_ids must be a list")
+    if not 2 <= len(paper_ids) <= MAX_PAPER_COUNT:
+        raise ValueError("paper_ids must contain between 2 and 8 distinct IDs")
+    normalized_ids = [normalize_paper_id(paper_id) for paper_id in paper_ids]
+    if len(set(normalized_ids)) != len(normalized_ids):
+        raise ValueError("paper_ids must be distinct")
+    for paper_id in normalized_ids:
+        workspace.get_paper(paper_id)
+    return normalized_ids
+
+
+def _validate_max_candidates_per_paper(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("max_candidates_per_paper must be an integer")
+    if not 1 <= value <= 20:
+        raise ValueError("max_candidates_per_paper must be between 1 and 20")
+    return value
+
+
+def _normalize_focus(focus: str | None) -> str | None:
+    if focus is None:
+        return None
+    compact = " ".join(str(focus).split())
+    return compact or None
+
+
+def _focus_tokens(focus: str | None) -> set[str]:
+    if focus is None:
+        return set()
+    return {token for token in focus.lower().split() if len(token) >= 3}
+
+
+def _paper_summaries(paper_maps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    papers = []
+    for paper_map in paper_maps:
+        paper = paper_map["paper"]
+        papers.append(
+            {
+                "paper_id": paper["paper_id"],
+                "title": paper.get("title"),
+                "paper_map_summary": paper_map["summary"],
+                "paper": paper,
+                "main_result_candidates": paper_map["main_result_candidates"],
+                "reading_route_preview": paper_map["reading_route"][:5],
+                "single_paper_report_command": (
+                    "papergraph-mcp --workspace <WORKSPACE> "
+                    f"export-paper-reading-report --paper-id {paper['paper_id']}"
+                ),
+                "warnings": paper_map["evidence_quality"]["warnings"],
+            }
+        )
+    return papers
+
+
+def _cross_paper_edges(
+    workspace: Workspace,
+    selected_paper_ids: list[str],
+) -> list[dict[str, Any]]:
+    selected = set(selected_paper_ids)
+    input_index = {paper_id: index for index, paper_id in enumerate(selected_paper_ids)}
+    edges_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for source_paper_id in selected_paper_ids:
+        for citation in workspace.get_citations(source_paper_id):
+            target = citation.get("target_paper_id")
+            if target in selected and target != source_paper_id:
+                mention_id = (
+                    f"citation:{source_paper_id}:{citation.get('citation_key')}"
+                )
+                edge = {
+                    "source_paper_id": source_paper_id,
+                    "target_paper_id": target,
+                    "kind": "citation_evidence",
+                    "citation_key": citation.get("citation_key"),
+                    "source_result_id": None,
+                    "source_proof_id": None,
+                    "mention_id": mention_id,
+                    "raw_text": citation.get("command") or citation.get("citation_key"),
+                    "evidence": citation,
+                }
+                edges_by_key[(source_paper_id, target, mention_id)] = edge
+
+        plan = workspace.plan_external_imports_for_paper(source_paper_id)
+        for candidate in plan.get("candidates", []):
+            target = (candidate.get("source") or {}).get("recommended_paper_id")
+            if target in selected and target != source_paper_id:
+                edge = _edge_from_import_candidate(source_paper_id, target, candidate)
+                edges_by_key[
+                    (source_paper_id, target, edge["mention_id"])
+                ] = edge
+
+    return sorted(
+        edges_by_key.values(),
+        key=lambda edge: (
+            input_index[edge["source_paper_id"]],
+            input_index[edge["target_paper_id"]],
+            edge["mention_id"],
+        ),
+    )
+
+
+def _edge_from_import_candidate(
+    source_paper_id: str,
+    target_paper_id: str,
+    candidate: dict[str, Any],
+) -> dict[str, Any]:
+    evidence = candidate.get("evidence") or []
+    mention_id = (
+        next(
+            (
+                item.get("evidence_id")
+                for item in evidence
+                if item.get("kind")
+                in {"external_result_mention", "citation_mention"}
+                and item.get("evidence_id")
+            ),
+            None,
+        )
+        or candidate["candidate_id"]
+    )
+    review = candidate.get("review") or {}
+    citation_keys = review.get("citation_keys") or []
+    raw_texts = review.get("raw_texts") or []
+    local_result_ids = review.get("local_result_ids") or []
+    proof_ids = review.get("proof_ids") or []
+    return {
+        "source_paper_id": source_paper_id,
+        "target_paper_id": target_paper_id,
+        "kind": "citation_evidence",
+        "citation_key": citation_keys[0] if citation_keys else None,
+        "source_result_id": local_result_ids[0] if local_result_ids else None,
+        "source_proof_id": proof_ids[0] if proof_ids else None,
+        "mention_id": mention_id,
+        "raw_text": raw_texts[0] if raw_texts else None,
+        "evidence": {
+            "source": "external_import_plan",
+            "candidate_id": candidate["candidate_id"],
+            "status": candidate.get("status"),
+            "review": review,
+        },
+    }
+
+
+def _external_risks(
+    workspace: Workspace,
+    selected_paper_ids: list[str],
+    cross_edges: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    selected = set(selected_paper_ids)
+    selected_edge_targets = {
+        (edge["source_paper_id"], edge["target_paper_id"]) for edge in cross_edges
+    }
+    risks = []
+    for source_paper_id in selected_paper_ids:
+        plan = workspace.plan_external_imports_for_paper(source_paper_id)
+        for candidate in plan.get("candidates", []):
+            source = candidate.get("source") or {}
+            target = source.get("recommended_paper_id")
+            if target in selected and (source_paper_id, target) in selected_edge_targets:
+                continue
+            risks.append(
+                {
+                    "source_paper_id": source_paper_id,
+                    "kind": "external_candidate",
+                    "status": candidate.get("status"),
+                    "target_paper_id": target,
+                    "candidate": candidate,
+                }
+            )
+        for item in plan.get("blocked", []):
+            risks.append(
+                {
+                    "source_paper_id": source_paper_id,
+                    "kind": "blocked",
+                    "status": "blocked",
+                    "target_paper_id": item.get("paper_id"),
+                    "candidate": item,
+                }
+            )
+    return risks
+
+
+def _recommended_sequence(
+    paper_ids: list[str],
+    paper_maps: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    focus: str | None,
+) -> tuple[list[dict[str, Any]], bool]:
+    input_index = {paper_id: index for index, paper_id in enumerate(paper_ids)}
+    outgoing_edge_sources = {edge["source_paper_id"] for edge in edges}
+    candidate_rows = []
+    tokens = _focus_tokens(focus)
+    for paper_map in paper_maps:
+        paper_id = paper_map["paper"]["paper_id"]
+        for candidate_index, candidate in enumerate(paper_map["main_result_candidates"]):
+            focus_match = _candidate_matches_focus(candidate, tokens)
+            candidate_rows.append(
+                {
+                    "paper_id": paper_id,
+                    "candidate": candidate,
+                    "candidate_index": candidate_index,
+                    "focus_match": focus_match,
+                }
+            )
+
+    if candidate_rows:
+        candidate_rows.sort(
+            key=lambda row: (
+                not row["focus_match"] if tokens else False,
+                row["paper_id"] not in outgoing_edge_sources,
+                -int(row["candidate"].get("score") or 0),
+                input_index[row["paper_id"]],
+                _source_position(row["candidate"].get("source_span")),
+                row["candidate"]["result_id"],
+            )
+        )
+        start_row = candidate_rows[0]
+        focus_matched = any(row["focus_match"] for row in candidate_rows) if tokens else False
+    else:
+        start_row = None
+        focus_matched = False
+
+    sequence = []
+    included: set[str] = set()
+    if start_row is not None:
+        paper_id = start_row["paper_id"]
+        candidate = start_row["candidate"]
+        sequence.append(
+            {
+                "position": 1,
+                "paper_id": paper_id,
+                "result_id": candidate["result_id"],
+                "role": "start",
+                "reason": "selected_main_candidate",
+                "evidence": {
+                    "source": "paper_map.main_result_candidates",
+                    "score": candidate.get("score"),
+                    "focus": focus,
+                    "focus_match": bool(tokens and start_row["focus_match"]),
+                },
+            }
+        )
+        included.add(paper_id)
+
+    for edge in edges:
+        if edge["target_paper_id"] not in included:
+            sequence.append(
+                {
+                    "position": len(sequence) + 1,
+                    "paper_id": edge["target_paper_id"],
+                    "result_id": None,
+                    "role": "context",
+                    "reason": "selected_paper_citation",
+                    "evidence": {
+                        "source": "cross_paper_edges",
+                        "source_paper_id": edge["source_paper_id"],
+                        "mention_id": edge["mention_id"],
+                    },
+                }
+            )
+            included.add(edge["target_paper_id"])
+
+    for paper_map in paper_maps:
+        paper_id = paper_map["paper"]["paper_id"]
+        if paper_id in included:
+            continue
+        candidates = paper_map["main_result_candidates"]
+        sequence.append(
+            {
+                "position": len(sequence) + 1,
+                "paper_id": paper_id,
+                "result_id": candidates[0]["result_id"] if candidates else None,
+                "role": "continue" if candidates else "review",
+                "reason": "input_order",
+                "evidence": {"source": "paper_ids.input_order"},
+            }
+        )
+        included.add(paper_id)
+
+    return sequence, focus_matched
+
+
+def _candidate_matches_focus(candidate: dict[str, Any], tokens: set[str]) -> bool:
+    if not tokens:
+        return False
+    haystack = " ".join(
+        [
+            str(candidate.get("label") or ""),
+            str(candidate.get("title") or ""),
+            str(candidate.get("statement_preview") or ""),
+            " ".join(
+                str(reason.get("evidence") or "")
+                for reason in candidate.get("reasons", [])
+            ),
+        ]
+    ).lower()
+    return all(token in haystack for token in tokens)
+
+
+def _summary(
+    paper_ids: list[str],
+    paper_maps: list[dict[str, Any]],
+    cross_edges: list[dict[str, Any]],
+    external_risks: list[dict[str, Any]],
+    sequence: list[dict[str, Any]],
+) -> dict[str, Any]:
+    statuses = [paper_map["summary"]["evidence_status"] for paper_map in paper_maps]
+    if any(status == "usable" for status in statuses):
+        status = "usable"
+    elif any(status == "sparse" for status in statuses):
+        status = "sparse"
+    else:
+        status = "limited"
+    start = sequence[0] if sequence else {}
+    return {
+        "paper_count": len(paper_ids),
+        "recommended_start_paper_id": start.get("paper_id"),
+        "recommended_start_result_id": start.get("result_id"),
+        "main_candidate_count": sum(
+            len(paper_map["main_result_candidates"]) for paper_map in paper_maps
+        ),
+        "cross_paper_edge_count": len(cross_edges),
+        "external_risk_count": sum(
+            1 for risk in external_risks if risk["kind"] == "external_candidate"
+        ),
+        "unresolved_risk_count": sum(
+            1 for risk in external_risks if risk["kind"] == "blocked"
+        ),
+        "evidence_status": status,
+    }
+
+
+def _warnings(
+    paper_maps: list[dict[str, Any]],
+    cross_edges: list[dict[str, Any]],
+    external_risks: list[dict[str, Any]],
+    focus: str | None,
+    focus_matched: bool,
+) -> list[dict[str, Any]]:
+    warnings = []
+    if focus and not focus_matched:
+        warnings.append(
+            {
+                "kind": "focus_no_match",
+                "message": "Focus text did not match extracted candidate evidence.",
+                "evidence": {"focus": focus},
+            }
+        )
+    if not cross_edges:
+        warnings.append(
+            {
+                "kind": "no_cross_paper_edges",
+                "message": (
+                    "No selected-paper citation edge was extracted between "
+                    "the selected papers."
+                ),
+                "evidence": {"edge_count": 0},
+            }
+        )
+    sparse_ids = [
+        paper_map["paper"]["paper_id"]
+        for paper_map in paper_maps
+        if paper_map["summary"]["evidence_status"] == "sparse"
+    ]
+    limited_ids = [
+        paper_map["paper"]["paper_id"]
+        for paper_map in paper_maps
+        if paper_map["summary"]["evidence_status"] == "limited"
+    ]
+    if limited_ids:
+        warnings.append(
+            {
+                "kind": "limited_paper",
+                "message": "One or more selected papers has limited evidence.",
+                "evidence": {"paper_ids": limited_ids},
+            }
+        )
+    if sparse_ids:
+        warnings.append(
+            {
+                "kind": "sparse_paper",
+                "message": "One or more selected papers has sparse evidence.",
+                "evidence": {"paper_ids": sparse_ids},
+            }
+        )
+    external_count = sum(
+        1 for risk in external_risks if risk["kind"] == "external_candidate"
+    )
+    blocked_count = sum(1 for risk in external_risks if risk["kind"] == "blocked")
+    if external_count:
+        warnings.append(
+            {
+                "kind": "external_dependencies",
+                "message": "External import candidates remain outside the selected set.",
+                "evidence": {"external_risk_count": external_count},
+            }
+        )
+    if blocked_count:
+        warnings.append(
+            {
+                "kind": "unresolved_references",
+                "message": "Unresolved references remain in the selected evidence.",
+                "evidence": {"blocked_count": blocked_count},
+            }
+        )
+    warnings.sort(
+        key=lambda warning: (
+            WARNING_ORDER[warning["kind"]],
+            warning["kind"],
+            json.dumps(warning.get("evidence"), sort_keys=True),
+        )
+    )
+    return warnings
+
+
+def _render_paper_set(papers: list[dict[str, Any]]) -> list[str]:
+    lines = []
+    for paper in papers:
+        metadata = paper["paper"]
+        summary = paper["paper_map_summary"]
+        lines.append(f"- `{paper['paper_id']}`")
+        lines.append(f"  - Title: {_text(metadata.get('title') or 'Unknown')}")
+        lines.append(f"  - Result count: {metadata['result_count']}")
+        lines.append(f"  - Proof count: {metadata['proof_count']}")
+        lines.append(f"  - Citation count: {metadata['citation_count']}")
+        lines.append(f"  - Evidence status: `{summary['evidence_status']}`")
+        lines.append(
+            "  - Recommended start result: "
+            f"{_code_or_none(summary['recommended_start_result_id'])}"
+        )
+    return lines
+
+
+def _render_sequence(sequence: list[dict[str, Any]]) -> list[str]:
+    if not sequence:
+        return ["No reading sequence could be built from supported evidence."]
+    lines = []
+    for item in sequence:
+        result = f" / `{item['result_id']}`" if item.get("result_id") else ""
+        lines.append(
+            f"{item['position']}. `{item['paper_id']}`{result} "
+            f"{item['role']} - {item['reason']} "
+            f"(evidence: {_compact_json(item.get('evidence'))})"
+        )
+    return lines
+
+
+def _render_edges(edges: list[dict[str, Any]]) -> list[str]:
+    if not edges:
+        return [
+            (
+                "No selected-paper citation edge was extracted between "
+                "the selected papers."
+            )
+        ]
+    lines = []
+    for edge in edges:
+        lines.append(
+            f"- `{edge['source_paper_id']}` cites selected paper "
+            f"`{edge['target_paper_id']}`."
+        )
+        lines.append(f"  - Mention: `{edge['mention_id']}`")
+        lines.append(f"  - Citation key: {_code_or_none(edge.get('citation_key'))}")
+        if edge.get("source_result_id"):
+            lines.append(f"  - Source result: `{edge['source_result_id']}`")
+        if edge.get("source_proof_id"):
+            lines.append(f"  - Source proof: `{edge['source_proof_id']}`")
+        if edge.get("raw_text"):
+            lines.append(f"  - Raw text: {_text(edge['raw_text'])}")
+    return lines
+
+
+def _render_candidates(papers: list[dict[str, Any]]) -> list[str]:
+    lines = []
+    for paper in papers:
+        lines.append(f"### {_text(paper['paper_id'])}")
+        candidates = paper["main_result_candidates"]
+        if not candidates:
+            lines.append("- No main-result candidates were found.")
+            continue
+        for candidate in candidates:
+            lines.append(
+                f"- `{candidate['result_id']}` "
+                f"({candidate.get('display_kind') or 'result'}), "
+                f"score {candidate.get('score')}"
+            )
+            if candidate.get("title"):
+                lines.append(f"  - Title: {_text(candidate['title'])}")
+            for reason in candidate.get("reasons", []):
+                lines.append(
+                    f"  - `{reason['kind']}` weight {reason['weight']}: "
+                    f"{_text(reason['evidence'])}"
+                )
+    return lines
+
+
+def _render_report_commands(papers: list[dict[str, Any]]) -> list[str]:
+    lines = ["```powershell"]
+    lines.extend(paper["single_paper_report_command"] for paper in papers)
+    lines.append("```")
+    return lines
+
+
+def _render_external_risks(risks: list[dict[str, Any]]) -> list[str]:
+    if not risks:
+        return ["No external risks outside the selected set were found."]
+    lines = []
+    for risk in risks:
+        candidate = risk["candidate"]
+        if risk["kind"] == "blocked":
+            reason = candidate.get("reason") or candidate.get("message") or "blocked"
+            lines.append(f"- `{risk['source_paper_id']}` blocked: {_text(reason)}")
+            continue
+        source = candidate.get("source") or {}
+        arxiv_id = source.get("arxiv_id") or risk.get("target_paper_id")
+        lines.append(
+            f"- `{risk['source_paper_id']}` external candidate: "
+            f"{_text(arxiv_id or candidate.get('candidate_id'))}"
+        )
+        review = candidate.get("review") or {}
+        if review.get("citation_keys"):
+            lines.append(
+                "  - Citation keys: "
+                + ", ".join(str(key) for key in review["citation_keys"])
+            )
+        if review.get("evidence_summary"):
+            lines.append(f"  - Review summary: {_text(review['evidence_summary'])}")
+    return lines
+
+
+def _render_warnings(
+    warnings: list[dict[str, Any]],
+    papers: list[dict[str, Any]],
+) -> list[str]:
+    lines = []
+    if warnings:
+        for warning in warnings:
+            lines.append(f"- `{warning['kind']}`: {_text(warning['message'])}")
+            if warning.get("evidence"):
+                lines.append(f"  - Evidence: {_compact_json(warning['evidence'])}")
+    else:
+        lines.append("- No plan-level evidence-quality warnings were produced.")
+    for paper in papers:
+        for warning in paper["warnings"]:
+            lines.append(
+                f"- `{paper['paper_id']}` `{warning['kind']}`: "
+                f"{_text(warning['message'])}"
+            )
+    return lines
+
+
+def _source_position(location: dict[str, Any] | None) -> tuple[int, int, int, str]:
+    if not location:
+        return (0, 0, 0, "")
+    return (
+        int(location.get("page") or 0),
+        int(location.get("block_index") or 0),
+        int(location.get("start_offset") or 0),
+        str(location.get("span_id") or ""),
+    )
+
+
+def _compact_json(value: Any) -> str:
+    if value is None:
+        return "`None`"
+    return "`" + json.dumps(value, sort_keys=True, ensure_ascii=False) + "`"
+
+
+def _code_or_none(value: str | None) -> str:
+    if value is None:
+        return "`None`"
+    return f"`{value}`"
+
+
+def _text(value: Any) -> str:
+    compact = " ".join(str(value).split())
+    return (
+        compact.replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("*", "\\*")
+        .replace("_", "\\_")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+    )

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -689,6 +689,25 @@ def workspace_export_paper_reading_report(
 
 
 @mcp.tool()
+@_serialized_workspace_tool
+def workspace_export_cross_paper_reading_plan(
+    paper_ids: list[str],
+    focus: str | None = None,
+    max_candidates_per_paper: int = 3,
+) -> dict:
+    """Export a deterministic Markdown reading plan for selected papers."""
+
+    try:
+        return require_workspace().export_cross_paper_reading_plan(
+            paper_ids,
+            focus=focus,
+            max_candidates_per_paper=max_candidates_per_paper,
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        raise ToolError(str(exc)) from exc
+
+
+@mcp.tool()
 def load_paper(path: str) -> dict:
     """Load a local LaTeX paper and build its theorem graph."""
 

--- a/src/papergraph/server.py
+++ b/src/papergraph/server.py
@@ -1006,6 +1006,60 @@ def _run_reading_report_cli_command(
             workspace.close()
 
 
+def _run_cross_paper_reading_plan_cli_command(
+    command: str,
+    workspace_path: str,
+    paper_ids: list[str],
+    focus: str | None,
+    max_candidates_per_paper: int,
+    output: str | None,
+) -> None:
+    workspace = None
+    try:
+        workspace = Workspace.open(workspace_path)
+        plan = workspace.export_cross_paper_reading_plan(
+            paper_ids,
+            focus=focus,
+            max_candidates_per_paper=max_candidates_per_paper,
+        )
+        markdown = plan["markdown"]
+        if output is None:
+            print(markdown, end="")
+            return
+
+        output_path = Path(output)
+        parent = output_path.parent
+        if parent != Path("") and not parent.exists():
+            raise ValueError(f"Parent directory does not exist: {parent}")
+        if output_path.exists() and output_path.is_dir():
+            raise ValueError(f"Output path is a directory: {output_path}")
+        output_path.write_text(markdown, encoding="utf-8")
+        _print_json(
+            {
+                "status": "written",
+                "command": command,
+                "paper_ids": plan["paper_ids"],
+                "format": plan["format"],
+                "output": str(output_path),
+                "bytes": len(output_path.read_bytes()),
+                "plan_schema_version": plan["plan_schema_version"],
+            }
+        )
+    except _WORKSPACE_TOOL_ERRORS as exc:
+        _print_json(
+            {
+                "status": "error",
+                "action": "inspect_error",
+                "command": command,
+                "message": str(exc),
+            }
+        )
+        raise SystemExit(1) from exc
+    finally:
+        if workspace is not None:
+            workspace.close()
+
+
 def _parse_json_argument(raw_json: str) -> dict:
     try:
         payload = json.loads(raw_json)
@@ -1200,6 +1254,23 @@ def main(argv: Sequence[str] | None = None) -> None:
     reading_report_parser.add_argument("--paper-id", required=True)
     reading_report_parser.add_argument("--max-candidates", type=int, default=5)
     reading_report_parser.add_argument("--output")
+    cross_paper_plan_parser = subparsers.add_parser(
+        "export-cross-paper-reading-plan",
+        help="Export a deterministic Markdown reading plan for selected papers.",
+    )
+    cross_paper_plan_parser.add_argument("--workspace", required=True)
+    cross_paper_plan_parser.add_argument(
+        "--paper-id",
+        action="append",
+        required=True,
+    )
+    cross_paper_plan_parser.add_argument("--focus")
+    cross_paper_plan_parser.add_argument(
+        "--max-candidates-per-paper",
+        type=int,
+        default=3,
+    )
+    cross_paper_plan_parser.add_argument("--output")
 
     args = parser.parse_args(argv)
     if args.command == "doctor":
@@ -1424,6 +1495,16 @@ def main(argv: Sequence[str] | None = None) -> None:
             args.workspace,
             args.paper_id,
             args.max_candidates,
+            args.output,
+        )
+        return
+    if args.command == "export-cross-paper-reading-plan":
+        _run_cross_paper_reading_plan_cli_command(
+            args.command,
+            args.workspace,
+            args.paper_id,
+            args.focus,
+            args.max_candidates_per_paper,
             args.output,
         )
         return

--- a/src/papergraph/workspace.py
+++ b/src/papergraph/workspace.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from threading import RLock
 
 from papergraph.citations import build_citation_records
+from papergraph.cross_paper_reading_plan import build_cross_paper_reading_plan
 from papergraph.evidence import (
     EVIDENCE_EMPTY_DEPENDENCY_WARNING,
     bounded_excerpt,
@@ -1919,6 +1920,22 @@ class Workspace:
             self,
             paper_id,
             max_candidates=max_candidates,
+        )
+
+    @_synchronized
+    def export_cross_paper_reading_plan(
+        self,
+        paper_ids: list[str],
+        focus: str | None = None,
+        max_candidates_per_paper: int = 3,
+    ) -> dict:
+        """Export a deterministic Markdown reading plan for selected papers."""
+
+        return build_cross_paper_reading_plan(
+            self,
+            paper_ids,
+            focus=focus,
+            max_candidates_per_paper=max_candidates_per_paper,
         )
 
     @_synchronized

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_version_prints_distribution_version_without_starting_mcp(
         server.main(["--version"])
 
     assert caught.value.code == 0
-    assert capsys.readouterr().out == "papergraph-mcp 0.11.0\n"
+    assert capsys.readouterr().out == "papergraph-mcp 0.12.0\n"
 
 
 def test_help_describes_theorem_dependency_server_without_starting_mcp(
@@ -74,11 +74,11 @@ def test_doctor_prints_json_without_starting_mcp(
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.11.0",
-            "release_tag": "v0.11.0",
+            "version": "0.12.0",
+            "release_tag": "v0.12.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.11.0"
+                "papergraph-mcp.git@v0.12.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -88,7 +88,7 @@ def test_doctor_prints_json_without_starting_mcp(
 
     server.main(["doctor"])
 
-    assert json.loads(capsys.readouterr().out)["version"] == "0.11.0"
+    assert json.loads(capsys.readouterr().out)["version"] == "0.12.0"
 
 
 def test_validate_arxiv_cli_prints_conflict_json_without_starting_mcp(

--- a/tests/test_cli_cross_paper_reading_plan.py
+++ b/tests/test_cli_cross_paper_reading_plan.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import papergraph.server as server
+from papergraph.workspace import Workspace
+from tests.test_workspace_cross_paper_reading_plan import import_arxiv_context_paper
+from tests.test_workspace_external_import_planner import import_import_plan_pdf
+
+
+def read_json(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+def create_cross_paper_workspace(tmp_path: Path) -> Path:
+    workspace_path = tmp_path / "workspace.sqlite3"
+    workspace = Workspace.open(workspace_path)
+    try:
+        import_import_plan_pdf(workspace, tmp_path)
+        import_arxiv_context_paper(workspace, tmp_path)
+    finally:
+        workspace.close()
+    return workspace_path
+
+
+def test_export_cross_paper_reading_plan_cli_prints_markdown(
+    tmp_path: Path,
+    capsys,
+):
+    workspace_path = create_cross_paper_workspace(tmp_path)
+
+    server.main(
+        [
+            "export-cross-paper-reading-plan",
+            "--workspace",
+            str(workspace_path),
+            "--paper-id",
+            "local:paper",
+            "--paper-id",
+            "arxiv:2401.12345",
+            "--focus",
+            "main",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert output.startswith("# Cross-Paper Reading Plan:")
+    assert "## Cross-Paper Evidence" in output
+    assert "## Next Commands" in output
+
+
+def test_export_cross_paper_reading_plan_cli_writes_output_file(
+    tmp_path: Path,
+    capsys,
+):
+    workspace_path = create_cross_paper_workspace(tmp_path)
+    output_path = tmp_path / "cross-paper-plan.md"
+
+    server.main(
+        [
+            "export-cross-paper-reading-plan",
+            "--workspace",
+            str(workspace_path),
+            "--paper-id",
+            "local:paper",
+            "--paper-id",
+            "arxiv:2401.12345",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    payload = read_json(capsys)
+    markdown = output_path.read_text(encoding="utf-8")
+    assert payload["status"] == "written"
+    assert payload["command"] == "export-cross-paper-reading-plan"
+    assert payload["paper_ids"] == ["local:paper", "arxiv:2401.12345"]
+    assert payload["format"] == "markdown"
+    assert payload["output"] == str(output_path)
+    assert payload["bytes"] == len(output_path.read_bytes())
+    assert payload["plan_schema_version"] == 1
+    assert markdown.startswith("# Cross-Paper Reading Plan:")
+    assert "PaperGraph does not verify proofs." in markdown
+
+
+def test_export_cross_paper_reading_plan_cli_reports_invalid_output_path(
+    tmp_path: Path,
+    capsys,
+):
+    workspace_path = create_cross_paper_workspace(tmp_path)
+    output_path = tmp_path / "missing" / "cross-paper-plan.md"
+
+    with pytest.raises(SystemExit) as caught:
+        server.main(
+            [
+                "export-cross-paper-reading-plan",
+                "--workspace",
+                str(workspace_path),
+                "--paper-id",
+                "local:paper",
+                "--paper-id",
+                "arxiv:2401.12345",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+    assert caught.value.code == 1
+    payload = read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["command"] == "export-cross-paper-reading-plan"
+    assert "Parent directory does not exist" in payload["message"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,11 +5,11 @@ def test_environment_diagnostics_reports_version_and_release_source():
     result = environment_diagnostics()
 
     assert result["package_name"] == "papergraph-mcp"
-    assert result["version"] == "0.11.0"
-    assert result["release_tag"] == "v0.11.0"
+    assert result["version"] == "0.12.0"
+    assert result["release_tag"] == "v0.12.0"
     assert (
         result["recommended_source"]
-        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0"
+        == "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0"
     )
     assert result["dependency_extraction_basis"] == "statement_explicit_latex_refs_only"
     assert isinstance(result["warnings"], list)
@@ -25,6 +25,6 @@ def test_environment_diagnostics_tolerates_missing_git(monkeypatch):
 
     result = environment_diagnostics()
 
-    assert result["version"] == "0.11.0"
+    assert result["version"] == "0.12.0"
     assert result["git"] is None
     assert any("Git context unavailable" in warning for warning in result["warnings"])

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents" / "skills" / "setting-up-papergraph"
-PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.11.0"
+PIN = "git+https://github.com/lotchuazzz-crypto/papergraph-mcp.git@v0.12.0"
 
 
 def read(path: Path) -> str:
@@ -118,7 +118,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
 
     class Result:
         returncode = 0
-        stdout = "papergraph-mcp 0.11.0\n"
+        stdout = "papergraph-mcp 0.12.0\n"
         stderr = ""
 
     def runner(command, **kwargs):
@@ -135,7 +135,7 @@ def test_checker_runs_the_exact_pinned_launch_command():
         "--version",
     ]
     assert result["ok"] is True
-    assert result["version"] == "papergraph-mcp 0.11.0"
+    assert result["version"] == "papergraph-mcp 0.12.0"
 
 
 def test_checker_rejects_an_unexpected_version_even_on_exit_zero():
@@ -181,7 +181,7 @@ def test_checker_main_smoke_test_emits_successful_launch_json(monkeypatch, capsy
         "commands": {"git": "/tools/git", "uv": "/tools/uv", "uvx": "/tools/uvx"},
         "ready_for_smoke_test": True,
     }
-    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.11.0"}
+    launch = {"ok": True, "reason": "ok", "version": "papergraph-mcp 0.12.0"}
     monkeypatch.setattr(checker, "inspect_prerequisites", lambda: prerequisites)
     monkeypatch.setattr(checker, "validate_launch", lambda: launch)
 
@@ -361,4 +361,4 @@ def test_all_onboarding_source_pins_match_v0100():
     )
     refs = re.findall(r"papergraph-mcp\.git@(v[^\s\"'\],)]+)", combined)
     assert refs
-    assert set(refs) == {"v0.11.0"}
+    assert set(refs) == {"v0.12.0"}

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,7 +24,7 @@ def test_project_metadata_is_discoverable_and_keeps_dependencies_separated():
     configuration = read_toml("pyproject.toml")
     project = configuration["project"]
 
-    assert project["version"] == "0.11.0"
+    assert project["version"] == "0.12.0"
     assert project["dependencies"] == [
         "httpx>=0.27,<1",
         "mcp[cli]>=2,<3",
@@ -70,7 +70,7 @@ def test_lockfile_contains_project_package():
     )
 
     assert package["name"] == "papergraph-mcp"
-    assert package["version"] == "0.11.0"
+    assert package["version"] == "0.12.0"
 
 
 def test_validate_arxiv_request_module_stdout_is_json_only():
@@ -102,8 +102,8 @@ def test_runtime_and_issue_template_release_strings_remain_pinned():
         if item.get("id") == "version"
     )
 
-    assert f'PaperGraph/0.11.0 (+{REPOSITORY_URL})' in arxiv_source
-    assert version_field["attributes"]["placeholder"] == "0.11.0"
+    assert f'PaperGraph/0.12.0 (+{REPOSITORY_URL})' in arxiv_source
+    assert version_field["attributes"]["placeholder"] == "0.12.0"
 
 
 def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
@@ -144,7 +144,7 @@ def test_ci_workflow_is_cross_platform_locked_and_least_privilege():
         for token in ('"uv"', '"pip"', '"install"', '"--python"')
     )
     assert "papergraph-mcp --version" in build_steps
-    assert "papergraph-mcp 0.11.0" in build_steps
+    assert "papergraph-mcp 0.12.0" in build_steps
     assert 'version="$(.smoke-venv/bin/papergraph-mcp --version)"' in build_steps
 
 
@@ -252,7 +252,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     pinned_source = (
         "git+https://github.com/lotchuazzz-crypto/"
-        "papergraph-mcp.git@v0.11.0"
+        "papergraph-mcp.git@v0.12.0"
     )
 
     for badge in ("CI", "Python", "MIT", "Release"):
@@ -263,7 +263,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     )
     assert '"command": "uvx"' in readme
     assert pinned_source in readme
-    assert "PaperGraph v0.11.0" in readme
+    assert "PaperGraph v0.12.0" in readme
 
     for tool_name in (
         "load_paper",
@@ -312,6 +312,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
         "workspace_plan_external_imports_for_paper",
         "workspace_get_paper_map",
         "workspace_export_paper_reading_report",
+        "workspace_export_cross_paper_reading_plan",
     ):
         assert f"`{tool_name}`" in readme
 
@@ -343,6 +344,7 @@ def test_readme_is_a_version_pinned_launch_page_with_verified_demo():
     assert "plan-external-imports-for-paper" in readme
     assert "get-paper-map" in readme
     assert "export-paper-reading-report" in readme
+    assert "export-cross-paper-reading-plan" in readme
     assert "--workspace" in readme
     assert "`get_environment_diagnostics`" in readme
     assert "`validate_arxiv_request`" in readme
@@ -416,8 +418,8 @@ def test_onboarding_uses_v061_release_pin_and_mentions_id_url_conflicts():
         ROOT / ".agents/skills/setting-up-papergraph/references/usage-prompt.md"
     ).read_text(encoding="utf-8")
 
-    assert "papergraph-mcp.git@v0.11.0" in skill
-    assert "papergraph-mcp 0.11.0" in skill
+    assert "papergraph-mcp.git@v0.12.0" in skill
+    assert "papergraph-mcp 0.12.0" in skill
     assert "validate_arxiv_request" in skill
     assert "load_arxiv_request" in skill
     assert "If a user provides both an arXiv ID and an arXiv URL" in skill

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,11 +169,11 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         "environment_diagnostics",
         lambda: {
             "package_name": "papergraph-mcp",
-            "version": "0.11.0",
-            "release_tag": "v0.11.0",
+            "version": "0.12.0",
+            "release_tag": "v0.12.0",
             "recommended_source": (
                 "git+https://github.com/lotchuazzz-crypto/"
-                "papergraph-mcp.git@v0.11.0"
+                "papergraph-mcp.git@v0.12.0"
             ),
             "dependency_extraction_basis": "statement_explicit_latex_refs_only",
             "git": None,
@@ -181,7 +181,7 @@ def test_get_environment_diagnostics_returns_runtime_metadata(monkeypatch):
         },
     )
 
-    assert server.get_environment_diagnostics()["release_tag"] == "v0.11.0"
+    assert server.get_environment_diagnostics()["release_tag"] == "v0.12.0"
 
 
 def test_validate_arxiv_input_tool_reports_conflict():

--- a/tests/test_workspace_cross_paper_reading_plan.py
+++ b/tests/test_workspace_cross_paper_reading_plan.py
@@ -1,0 +1,200 @@
+from pathlib import Path
+
+import pytest
+
+from papergraph.project import load_project
+from papergraph.workspace import Workspace
+from tests.test_workspace_external_import_planner import import_import_plan_pdf
+from tests.test_workspace_paper_map import import_paper_map_pdf
+
+
+def import_arxiv_context_paper(workspace: Workspace, tmp_path: Path) -> None:
+    tex = tmp_path / "context.tex"
+    tex.write_text(
+        "\n".join(
+            [
+                r"\documentclass{article}",
+                r"\newtheorem{theorem}{Theorem}",
+                r"\begin{document}",
+                r"\begin{theorem}\label{main}",
+                "Context fixed point theorem.",
+                r"\end{theorem}",
+                r"\begin{proof}",
+                "This is direct.",
+                r"\end{proof}",
+                r"\end{document}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    workspace.import_project(
+        "arxiv:2401.12345",
+        "arxiv",
+        "2401.12345",
+        None,
+        load_project(tex),
+    )
+
+
+def insert_empty_paper(workspace: Workspace, paper_id: str) -> None:
+    workspace._connection.execute(
+        """
+        INSERT INTO papers (
+            paper_id, source_type, source_ref, source_version, title,
+            authors_json, main_file, imported_at, parser_version
+        ) VALUES (
+            ?, 'pdf', ?, NULL, NULL,
+            '[]', ?, '2026-09-12T00:00:00+00:00', 'test'
+        )
+        """,
+        (paper_id, f"{paper_id}.pdf", f"{paper_id}.pdf"),
+    )
+    workspace._connection.commit()
+
+
+def test_cross_paper_reading_plan_exports_markdown_payload(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_import_plan_pdf(workspace, tmp_path)
+        import_arxiv_context_paper(workspace, tmp_path)
+
+        plan = workspace.export_cross_paper_reading_plan(
+            ["local:paper", "arxiv:2401.12345"],
+            focus="main result",
+            max_candidates_per_paper=2,
+        )
+
+        assert plan["plan_schema_version"] == 1
+        assert plan["format"] == "markdown"
+        assert plan["paper_ids"] == ["local:paper", "arxiv:2401.12345"]
+        assert plan["focus"] == "main result"
+        assert plan["summary"]["paper_count"] == 2
+        assert plan["summary"]["recommended_start_paper_id"] == "local:paper"
+        assert plan["summary"]["recommended_start_result_id"]
+        assert plan["summary"]["cross_paper_edge_count"] == 1
+        assert plan["summary"]["evidence_status"] == "usable"
+        assert len(plan["papers"]) == 2
+        assert plan["cross_paper_edges"][0]["source_paper_id"] == "local:paper"
+        assert (
+            plan["cross_paper_edges"][0]["target_paper_id"]
+            == "arxiv:2401.12345"
+        )
+        assert plan["recommended_sequence"][0]["role"] == "start"
+        assert (
+            plan["recommended_sequence"][0]["reason"]
+            == "selected_main_candidate"
+        )
+        markdown = plan["markdown"]
+        assert markdown.startswith("# Cross-Paper Reading Plan:")
+        assert "## Paper Set" in markdown
+        assert "## Recommended Reading Sequence" in markdown
+        assert "## Cross-Paper Evidence" in markdown
+        assert (
+            "`local:paper` cites selected paper `arxiv:2401.12345`"
+            in markdown
+        )
+        assert "## Per-Paper Reading Reports" in markdown
+        assert "export-paper-reading-report" in markdown
+        assert "Citation evidence does not imply logical dependency" in markdown
+    finally:
+        workspace.close()
+
+
+def test_cross_paper_reading_plan_warns_without_edges(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_paper_map_pdf(workspace, tmp_path)
+        insert_empty_paper(workspace, "local:empty")
+
+        plan = workspace.export_cross_paper_reading_plan(
+            ["local:paper", "local:empty"],
+        )
+
+        assert plan["cross_paper_edges"] == []
+        assert any(
+            warning["kind"] == "no_cross_paper_edges"
+            for warning in plan["warnings"]
+        )
+        assert (
+            "No selected-paper citation edge was extracted"
+            in plan["markdown"]
+        )
+    finally:
+        workspace.close()
+
+
+def test_cross_paper_reading_plan_rejects_invalid_inputs(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_paper_map_pdf(workspace, tmp_path)
+        insert_empty_paper(workspace, "local:empty")
+
+        with pytest.raises(ValueError, match="between 2 and 8"):
+            workspace.export_cross_paper_reading_plan(["local:paper"])
+        with pytest.raises(ValueError, match="between 2 and 8"):
+            workspace.export_cross_paper_reading_plan(
+                [f"local:p{index}" for index in range(9)]
+            )
+        with pytest.raises(ValueError, match="distinct"):
+            workspace.export_cross_paper_reading_plan(
+                ["local:paper", "local:paper"]
+            )
+        with pytest.raises(KeyError, match="Unknown paper id"):
+            workspace.export_cross_paper_reading_plan(
+                ["local:paper", "local:missing"]
+            )
+        with pytest.raises(ValueError, match="max_candidates_per_paper"):
+            workspace.export_cross_paper_reading_plan(
+                ["local:paper", "local:empty"],
+                max_candidates_per_paper=True,
+            )
+        with pytest.raises(ValueError, match="between 1 and 20"):
+            workspace.export_cross_paper_reading_plan(
+                ["local:paper", "local:empty"],
+                max_candidates_per_paper=0,
+            )
+    finally:
+        workspace.close()
+
+
+def test_cross_paper_reading_plan_focus_no_match_warns(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_import_plan_pdf(workspace, tmp_path)
+        import_arxiv_context_paper(workspace, tmp_path)
+
+        plan = workspace.export_cross_paper_reading_plan(
+            ["local:paper", "arxiv:2401.12345"],
+            focus="spectral sheaf",
+        )
+
+        assert any(
+            warning["kind"] == "focus_no_match"
+            for warning in plan["warnings"]
+        )
+        assert plan["summary"]["recommended_start_paper_id"] == "local:paper"
+    finally:
+        workspace.close()
+
+
+def test_cross_paper_reading_plan_includes_sparse_paper(tmp_path: Path):
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_paper_map_pdf(workspace, tmp_path)
+        insert_empty_paper(workspace, "local:empty")
+
+        plan = workspace.export_cross_paper_reading_plan(
+            ["local:paper", "local:empty"],
+        )
+
+        empty = next(
+            paper for paper in plan["papers"] if paper["paper_id"] == "local:empty"
+        )
+        assert empty["paper_map_summary"]["evidence_status"] == "limited"
+        assert any(
+            warning["kind"] == "limited_paper"
+            for warning in plan["warnings"]
+        )
+        assert "`local:empty`" in plan["markdown"]
+    finally:
+        workspace.close()

--- a/tests/test_workspace_cross_paper_reading_plan_server.py
+++ b/tests/test_workspace_cross_paper_reading_plan_server.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pytest
+from mcp.server.mcpserver.exceptions import ToolError
+
+import papergraph.server as server
+from papergraph.workspace import Workspace
+from tests.test_workspace_cross_paper_reading_plan import import_arxiv_context_paper
+from tests.test_workspace_external_import_planner import import_import_plan_pdf
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    server._reset_server_state()
+    yield
+    server._reset_server_state()
+
+
+def load_cross_paper_workspace(tmp_path: Path) -> None:
+    workspace = Workspace.open(tmp_path / "workspace.sqlite3")
+    try:
+        import_import_plan_pdf(workspace, tmp_path)
+        import_arxiv_context_paper(workspace, tmp_path)
+    finally:
+        workspace.close()
+    server.open_workspace(str(tmp_path / "workspace.sqlite3"))
+
+
+def test_cross_paper_reading_plan_mcp_tool_returns_payload(tmp_path: Path):
+    load_cross_paper_workspace(tmp_path)
+
+    plan = server.workspace_export_cross_paper_reading_plan(
+        ["local:paper", "arxiv:2401.12345"],
+        focus="main",
+        max_candidates_per_paper=1,
+    )
+
+    assert plan["plan_schema_version"] == 1
+    assert plan["format"] == "markdown"
+    assert plan["summary"]["paper_count"] == 2
+    assert plan["summary"]["cross_paper_edge_count"] == 1
+    assert "## Cross-Paper Evidence" in plan["markdown"]
+
+
+def test_cross_paper_reading_plan_mcp_tool_reports_missing_workspace():
+    with pytest.raises(ToolError, match="open_workspace"):
+        server.workspace_export_cross_paper_reading_plan(
+            ["local:paper", "arxiv:2401.12345"],
+        )
+
+
+def test_cross_paper_reading_plan_mcp_tool_converts_workspace_errors(
+    tmp_path: Path,
+):
+    server.open_workspace(str(tmp_path / "workspace.sqlite3"))
+
+    with pytest.raises(ToolError, match="Unknown paper id"):
+        server.workspace_export_cross_paper_reading_plan(
+            ["local:paper", "local:missing"],
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "papergraph-mcp"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Prepare PaperGraph v0.13.0 as the v1.0 readiness pass.

- Add the v1 core contract reference.
- Add a first-workspace walkthrough for MCP and CLI users.
- Add example Reading Report and Cross-Paper Reading Plan artifacts.
- Update README launch paths and release highlights.
- Bump pinned release/version references to 0.13.0.

## Testing

- `uv run pytest -q -p no:cacheprovider --basetemp .pytest-tmp`
- Result: `460 passed, 1 skipped`